### PR TITLE
Native hasher note for PHP 5.4 usage

### DIFF
--- a/usage/hashing.md
+++ b/usage/hashing.md
@@ -18,6 +18,8 @@ There are 5 built in hashers:
 
 The encouraged hasher to use in Sentinel is the native hasher. It will use PHP 5.5's `password_hash()` function and is setup to use the most secure hashing strategy of the day (which is current bcrypt). There is no setup required for this hasher.
 
+The native hasher can be used with PHP 5.4 by adding the ircmaxell/password-compat package to your composer.json file.
+
 <div name="bcrypt-hasher" data-unique="bcrypt-hasher"></div>
 
 #### Bcrypt Hasher


### PR DESCRIPTION
Added a note regarding the ircmaxell/password-compat package if you want to use the native hasher with PHP 5.4.
