### PR TITLE
More efficient flushing of user persistences

### DIFF
--- a/src/Persistences/IlluminatePersistenceRepository.php
+++ b/src/Persistences/IlluminatePersistenceRepository.php
@@ -201,14 +201,14 @@ class IlluminatePersistenceRepository implements PersistenceRepositoryInterface 
 			$this->forget($persistable);
 		}
 
-        $persistences = $persistable->{$persistable->getPersistableRelationship()}();
+		$persistences = $persistable->{$persistable->getPersistableRelationship()}();
 
-        if ($this->check() !== null)
-        {
-            $persistences->whereNotIn('code', [$this->check()]);
-        }
+		if ($this->check() !== null)
+		{
+			$persistences->whereNotIn('code', [$this->check()]);
+		}
 
-        $persistences->delete();
+		$persistences->delete();
 	}
 
 }


### PR DESCRIPTION
This PR refactors the flushing or user persistences so they happen in one DB call instead of pulling them and deleting them individually. It also removes the strict requirement (AFAIK) of the persistences table having an id column. This is very debatable but for large instances the table has a chance of overflowing since each login, regardless of single or multiple persistence, causes the id to increment. Not saying it's recommended to drop the column but this is more efficient so that's an added bonus incase someone would rather not have a an autoincrementing id column on a table that is not referenced elsewhere.
