### PR TITLE
Docs/1.0

### DIFF
--- a/usage/users.md
+++ b/usage/users.md
@@ -303,7 +303,7 @@ $user = Sentinel::update($user, $credentials);
 
 #### $user->delete()
 
-Deletes an existing user.
+Deletes an existing user and also removes the records from related Sentinel tables.
 
 ##### Example
 


### PR DESCRIPTION
I didn't know you could delete a user from reading the docs, so I added it. Wasn't sure exactly how to add it as it doesn't fit 100% with the previous methods as they all started with Sentinel::someMethod() and this is $user->delete() but I hope it fits ok. 

I was going to leave it as it is just an Eloquent method but you have extended it with extra delete functionality and I think it is worth having in the docs.
