### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,16 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 matrix:
-    allow_failures:
-        - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - composer self-update
+  - composer install
 
-script: phpunit
+script:
+  - phpunit


### PR DESCRIPTION
Do not download composer manually, use Travis' one.
Drop `--dev`, on by default for almost a year.