### PR TITLE
Set abstract method to protected

### DIFF
--- a/src/Permissions/PermissibleTrait.php
+++ b/src/Permissions/PermissibleTrait.php
@@ -80,7 +80,7 @@ trait PermissibleTrait {
 	 *
 	 * @return \Cartalyst\Sentinel\Permissions\PermissionsInterface
 	 */
-	abstract function createPermissions();
+	abstract protected function createPermissions();
 
 	/**
 	 * {@inheritDoc}


### PR DESCRIPTION
IDEs complain when you override an abstract public method with a
protected one.