### PR TITLE
Update EloquentUser.php

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -177,7 +177,7 @@ class EloquentUser extends Model implements RoleableInterface, PermissibleInterf
      * @param  mixed  $permissions
      * @return void
      */
-    public function setPermissionsAttribute(array $permissions)
+    public function setPermissionsAttribute(array $permissions = null)
     {
         $this->attributes['permissions'] = $permissions ? json_encode($permissions) : '';
     }


### PR DESCRIPTION
Getting the following error when using Reminder::complete($user, $code, $password) with a user that has no permissions set:

"Argument 1 passed to Cartalyst\Sentinel\Users\EloquentUser::setPermissionsAttribute() must be of the type array, null given"

Suggest defaulting parameter to null?