### PR TITLE
Added interface for the activation entity

### DIFF
--- a/src/Activations/ActivationInterface.php
+++ b/src/Activations/ActivationInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Part of the Sentinel package.
+ *
+ * NOTICE OF LICENSE
+ *
+ * Licensed under the 3-clause BSD License.
+ *
+ * This source file is subject to the 3-clause BSD License that is
+ * bundled with this package in the LICENSE file.
+ *
+ * @package    Sentinel
+ * @version    2.0.6
+ * @author     Cartalyst LLC
+ * @license    BSD License (3-clause)
+ * @copyright  (c) 2011-2015, Cartalyst LLC
+ * @link       http://cartalyst.com
+ */
+
+namespace Cartalyst\Sentinel\Activations;
+
+interface ActivationInterface
+{
+	/**
+	 * Return the random string used as activation code.
+	 *
+	 * @return string
+	 */
+	public function getCode();
+}

--- a/src/Activations/ActivationRepositoryInterface.php
+++ b/src/Activations/ActivationRepositoryInterface.php
@@ -28,7 +28,7 @@ interface ActivationRepositoryInterface
      * Create a new activation record and code.
      *
      * @param  \Cartalyst\Sentinel\Users\UserInterface  $user
-     * @return string
+     * @return ActivationInterface
      */
     public function create(UserInterface $user);
 
@@ -37,7 +37,7 @@ interface ActivationRepositoryInterface
      *
      * @param  \Cartalyst\Sentinel\Users\UserInterface  $user
      * @param  string  $code
-     * @return bool
+     * @return ActivationInterface|bool
      */
     public function exists(UserInterface $user, $code = null);
 
@@ -54,7 +54,7 @@ interface ActivationRepositoryInterface
      * Checks if a valid activation has been completed.
      *
      * @param  \Cartalyst\Sentinel\Users\UserInterface  $user
-     * @return bool
+     * @return ActivationInterface|bool
      */
     public function completed(UserInterface $user);
 

--- a/src/Activations/EloquentActivation.php
+++ b/src/Activations/EloquentActivation.php
@@ -22,7 +22,7 @@ namespace Cartalyst\Sentinel\Activations;
 
 use Illuminate\Database\Eloquent\Model;
 
-class EloquentActivation extends Model
+class EloquentActivation extends Model implements ActivationInterface
 {
     /**
      * {@inheritDoc}
@@ -58,5 +58,15 @@ class EloquentActivation extends Model
     public function setCompletedAttribute($completed)
     {
         $this->attributes['completed'] = (bool) $completed;
+    }
+
+    /**
+     * Return the random string used as activation code.
+     *
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->attributes['code'];
     }
 }

--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -220,7 +220,7 @@ class Sentinel
 
         $this->fireEvent('sentinel.activated', [ $user, $activation ]);
 
-        return $activations->complete($user, $activation->code);
+        return $activations->complete($user, $activation->getCode());
     }
 
     /**

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -87,9 +87,11 @@ class SentinelTest extends PHPUnit_Framework_TestCase
         $users->shouldReceive('validForCreation')->once()->andReturn(true);
         $users->shouldReceive('create')->once()->andReturn(m::mock('Cartalyst\Sentinel\Users\EloquentUser'));
 
-        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\EloquentActivation'));
+        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\ActivationInterface'));
         $activations->shouldReceive('complete')->once()->andReturn(true);
-        $activation->shouldReceive('getAttribute')->once();
+
+
+        $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->times(4);
 
@@ -105,9 +107,9 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $user = new EloquentUser;
 
-        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\EloquentActivation'));
+        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\ActivationInterface'));
         $activations->shouldReceive('complete')->once()->andReturn(true);
-        $activation->shouldReceive('getAttribute')->once();
+        $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
 
@@ -122,9 +124,9 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $users->shouldReceive('findById')->with('1')->once()->andReturn(new EloquentUser);
 
-        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\EloquentActivation'));
+        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\ActivationInterface'));
         $activations->shouldReceive('complete')->once()->andReturn(true);
-        $activation->shouldReceive('getAttribute')->once();
+        $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
 
@@ -142,9 +144,9 @@ class SentinelTest extends PHPUnit_Framework_TestCase
 
         $users->shouldReceive('findByCredentials')->with($credentials)->once()->andReturn(new EloquentUser);
 
-        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\EloquentActivation'));
+        $activations->shouldReceive('create')->once()->andReturn($activation = m::mock('Cartalyst\Sentinel\Activations\ActivationInterface'));
         $activations->shouldReceive('complete')->once()->andReturn(true);
-        $activation->shouldReceive('getAttribute')->once();
+        $activation->shouldReceive('getCode')->once()->andReturn('a_random_code');
 
         $dispatcher->shouldReceive('fire')->twice();
 


### PR DESCRIPTION
This is required if we implement an Activation outside of the default EloquentActivation.

Specifically, Sentinel was accessing $activation->code through Eloquent's accessors, and entities outside of Eloquent may not have this magic method implemented.