### PR TITLE
Find all roles

### DIFF
--- a/src/Roles/IlluminateRoleRepository.php
+++ b/src/Roles/IlluminateRoleRepository.php
@@ -89,6 +89,7 @@ class IlluminateRoleRepository implements RoleRepositoryInterface
     {
         return $this
             ->createModel()
+            ->newQuery()
             ->get();
     }
 }

--- a/src/Roles/IlluminateRoleRepository.php
+++ b/src/Roles/IlluminateRoleRepository.php
@@ -81,4 +81,14 @@ class IlluminateRoleRepository implements RoleRepositoryInterface
             ->where('name', $name)
             ->first();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function all()
+    {
+        return $this
+            ->createModel()
+            ->get();
+    }
 }

--- a/src/Roles/RoleRepositoryInterface.php
+++ b/src/Roles/RoleRepositoryInterface.php
@@ -45,4 +45,11 @@ interface RoleRepositoryInterface
      * @return \Cartalyst\Sentinel\Roles\RoleInterface
      */
     public function findByName($name);
+
+    /**
+     * Finds all roles.
+     *
+     * @return \IteratorAggregate
+     */
+    public function all();
 }

--- a/tests/IlluminateRoleRepositoryTest.php
+++ b/tests/IlluminateRoleRepositoryTest.php
@@ -82,4 +82,15 @@ class IlluminateRoleRepositoryTest extends PHPUnit_Framework_TestCase
 
         $roles->findByName('foo');
     }
+
+    public function testFindAll()
+    {
+        $roles = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository[createModel]');
+
+        $roles->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Roles\EloquentRole[newQuery]'));
+        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
+        $query->shouldReceive('get')->once();
+
+        $roles->all();
+    }
 }


### PR DESCRIPTION
As an administrator of a userland RBAC system, I'd probably want to list available roles in order to associate them with a user.
This functionality is missing from the repos, and they'd be extended for it, or the `EloquentRole::all()` method would have to be used.