### PR TITLE
Fix IlluminateUserRepository getHasher docblock

### DIFF
--- a/src/Users/IlluminateUserRepository.php
+++ b/src/Users/IlluminateUserRepository.php
@@ -320,7 +320,6 @@ class IlluminateUserRepository implements UserRepositoryInterface
     /**
      * Returns the hasher instance.
      *
-     * @param \Cartalyst\Sentinel\Hashing\HasherInterface  $hasher
      * @return void
      */
     public function getHasher()


### PR DESCRIPTION
getHasher() function didn't receive the parameter documented