### PR TITLE
Changing session closed test to PHP 5.4 construct

### DIFF
--- a/src/Sessions/NativeSession.php
+++ b/src/Sessions/NativeSession.php
@@ -86,7 +86,7 @@ class NativeSession implements SessionInterface
     protected function startSession()
     {
         // Check that the session hasn't already been started
-        if (session_id() == '' && ! headers_sent()) {
+        if (session_status() != PHP_SESSION_ACTIVE && ! headers_sent()) {
             session_start();
         }
     }


### PR DESCRIPTION
If a session has previously been opened then closed, session_id() will have a value. The session then fails to open. In PHP 5.4 session_status() was introduced which allows testing whether the session is actually open or closed.

With this change, the session is correctly re-opened after it has previously been opened and closed. See http://php.net/manual/en/function.session-status.php