### PR TITLE
Introducing "ALLOW first" policy

### DIFF
--- a/src/Permissions/PermissionsTrait.php
+++ b/src/Permissions/PermissionsTrait.php
@@ -143,9 +143,10 @@ trait PermissionsTrait
      *
      * @param  array  $prepared
      * @param  array  $permissions
+     * @param  bool   $allowIsAboveDeny
      * @return void
      */
-    protected function preparePermissions(array &$prepared, array $permissions)
+    protected function preparePermissions(array &$prepared, array $permissions, $allowIsAboveDeny = false)
     {
         foreach ($permissions as $keys => $value) {
             foreach ($this->extractClassPermissions($keys) as $key) {
@@ -156,8 +157,9 @@ trait PermissionsTrait
                     continue;
                 }
 
-                // If our value is in the array and equals false, it will override
-                if ($value === false) {
+                // If our value is in the array and equals false in case of "deny-first" policy; 
+                // or equals true in case of "allow-first" policy, it will override
+                if ($value === $allowIsAboveDeny) {
                     $prepared[$key] = $value;
                 }
             }


### PR DESCRIPTION
In certain scenarios, where ALLOW policy should weigh more than DENY (e.g. Subscription model where customer is granted rights in permissive manner, instead of restrictive - let's say he/she has two packages one with restrictive permission bit, the other with permissive: overall permission should have permissive outcome) our ```preparePermissions()``` method should calculate permissions accordingly. To that end, I decided to introduce a third argument to that method, which enables us to switch between permissive (ALLOW first) and restrictive (DENY first) policy modes. Default value of this argument will be ```false``` as it was before this implementation, for BC reasons.

Related unit-test to follow...