### PR TITLE
Fix of loosing sentinel userResolver for new instances of Request.

### DIFF
--- a/src/Laravel/SentinelServiceProvider.php
+++ b/src/Laravel/SentinelServiceProvider.php
@@ -448,8 +448,10 @@ class SentinelServiceProvider extends ServiceProvider
      */
     protected function setUserResolver()
     {
-        $this->app['request']->setUserResolver(function () {
-            return $this->app['sentinel']->getUser();
+        $this->app->rebinding('request', function ($app, $request) {
+            $request->setUserResolver(function () use ($app) {
+                return $app['sentinel']->getUser();
+            });
         });
     }
 }


### PR DESCRIPTION
Rebinding of 'userResolver' added. 
It will help get 'sentinel userResolver' instead of default when new instance of Request created.
https://github.com/laravel/framework/blob/5.1/src/Illuminate/Container/Container.php#L339