### PR TITLE
DocBlock fix for Sentinel::guest()

### DIFF
--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -263,7 +263,7 @@ class Sentinel
     /**
      * Checks if we are currently a guest.
      *
-     * @return \Cartalyst\Sentinel\Users\UserInterface|bool
+     * @return bool
      */
     public function guest()
     {


### PR DESCRIPTION
It always returns boolean. If ```check()``` returns an object, its negatory will be boolean ```FALSE```. Otherwise, we will have boolean ```TRUE```.