### PR TITLE
Added return to the parent call in delete()

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -407,7 +407,7 @@ class EloquentUser extends Model implements RoleableInterface, PermissibleInterf
             $this->throttle()->delete();
         }
 
-        parent::delete();
+        return parent::delete();
     }
 
     /**


### PR DESCRIPTION
This `return` statement is needed here to return the value which is returned by the called parent function (Laravel's own `delete()`). Without `return` before the parent function call, `$user->delete()` will only ever return `null`.