### PR TITLE
Use LOWER() to prevent case-sensitivity issues

### DIFF
--- a/src/Users/IlluminateUserRepository.php
+++ b/src/Users/IlluminateUserRepository.php
@@ -102,7 +102,7 @@ class IlluminateUserRepository implements UserRepositoryInterface
 
         if (is_array($logins)) {
             foreach ($logins as $key => $value) {
-                $query->where($key, $value);
+                $query->where($key, 'ILIKE', $value);
             }
         } else {
             $query->whereNested(function ($query) use ($loginNames, $logins) {


### PR DESCRIPTION
I notice that when using PostgreSQL, the user's login credential (email address, by default) is treated in a case-sensitive manner. So, joeblow@localhost.dev works, but JoeBlow@localhost.dev does not.

I'm not sure if the solution is as simple as what I'm proposing here, but I can't think of a scenario in which the username should ever be treated in a case-sensitive fashion (at least when email address is used as the primary user identifier; a username might be a different animal).