### PR TITLE
random_compat version update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/session": "~5.0",
         "ircmaxell/password-compat": "~1.0",
         "mockery/mockery": "~0.9",
-        "paragonie/random_compat": "~1.1",
+        "paragonie/random_compat": "^1.4|^2",
         "phpunit/phpunit": "~4.0"
     },
     "suggest": {


### PR DESCRIPTION
Some folks prefer version 1.x, others prefer version 2.x.

Version 2 doesn't fall back to OpenSSL, which is a [burning trash fire](https://github.com/ramsey/uuid/issues/80).