### PR TITLE
Hide password

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -46,7 +46,11 @@ class EloquentUser extends Model implements RoleableInterface, PermissibleInterf
         'first_name',
         'permissions',
     ];
-
+    
+    protected $hidden = [
+        'password',
+    ];
+    
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
JSON reponses outputs hashed passwords.
For security, hide it globally to avoid accidental leaks.