### PR TITLE
Throttling threshold mismatch

### DIFF
--- a/src/Native/SentinelBootstrapper.php
+++ b/src/Native/SentinelBootstrapper.php
@@ -122,7 +122,9 @@ class SentinelBootstrapper
 
         $model = $this->config['persistences']['model'];
 
-        return new IlluminatePersistenceRepository($session, $cookie, $model);
+	    $single = $this->config['persistences']['single'];
+
+        return new IlluminatePersistenceRepository($session, $cookie, $model, $single);
     }
 
     /**

--- a/src/Throttling/IlluminateThrottleRepository.php
+++ b/src/Throttling/IlluminateThrottleRepository.php
@@ -366,7 +366,7 @@ class IlluminateThrottleRepository implements ThrottleRepositoryInterface
                     return $this->secondsToFree($last, $delay);
                 }
             }
-        } elseif ($throttles->count() > $this->$thresholds) {
+        } elseif ($throttles->count() >= $this->$thresholds) {
             $interval = $type.'Interval';
 
             $first = $throttles->first();


### PR DESCRIPTION
Previously, if I set throttling threshold to 1 it was allowing me to add password three times.

This pull request is the solution for that bug.
