### PR TITLE
Depend on abstraction instead of concrete class for events dispatcher.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": ">=5.4.0",
         "cartalyst/support": "~1.0",
+        "illuminate/events": "~5.0",
         "illuminate/support": "~5.0"
     },
     "require-dev": {
@@ -31,7 +32,8 @@
         "ircmaxell/password-compat": "~1.0",
         "mockery/mockery": "~0.9",
         "paragonie/random_compat": "^1.4|^2",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "illuminate/contracts": "~5.0"
     },
     "suggest": {
         "illuminate/database": "By default, Sentinel utilizes the powerful Illuminate database layer.",

--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -31,7 +31,7 @@ use Cartalyst\Sentinel\Users\UserInterface;
 use Cartalyst\Sentinel\Users\UserRepositoryInterface;
 use Cartalyst\Support\Traits\EventTrait;
 use Closure;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -130,7 +130,7 @@ class Sentinel
      * @param  \Cartalyst\Sentinel\Users\UserRepositoryInterface  $users
      * @param  \Cartalyst\Sentinel\Roles\RoleRepositoryInterface  $roles
      * @param  \Cartalyst\Sentinel\Activations\ActivationRepositoryInterface  $activations
-     * @param  \Illuminate\Events\Dispatcher  $dispatcher
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @return void
      */
     public function __construct(

--- a/src/Users/IlluminateUserRepository.php
+++ b/src/Users/IlluminateUserRepository.php
@@ -25,7 +25,7 @@ use Cartalyst\Sentinel\Hashing\HasherInterface;
 use Cartalyst\Support\Traits\EventTrait;
 use Cartalyst\Support\Traits\RepositoryTrait;
 use Closure;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 
 class IlluminateUserRepository implements UserRepositoryInterface
@@ -50,7 +50,7 @@ class IlluminateUserRepository implements UserRepositoryInterface
      * Create a new Illuminate user repository.
      *
      * @param  \Cartalyst\Sentinel\Hashing\HasherInterface  $hasher
-     * @param  \Illuminate\Events\Dispatcher  $dispatcher
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @param  string  $model
      * @return void
      */

--- a/tests/CheckpointsTest.php
+++ b/tests/CheckpointsTest.php
@@ -219,7 +219,7 @@ class CheckpointsTest extends PHPUnit_Framework_TestCase
             $users        = m::mock('Cartalyst\Sentinel\Users\UserRepositoryInterface'),
             $roles        = m::mock('Cartalyst\Sentinel\Roles\RoleRepositoryInterface'),
             $activations  = m::mock('Cartalyst\Sentinel\Activations\ActivationRepositoryInterface'),
-            $dispatcher   = m::mock('Illuminate\Events\Dispatcher')
+            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')
         );
 
         $throttle = m::mock('Cartalyst\Sentinel\Throttling\ThrottleRepositoryInterface');

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -525,7 +525,7 @@ class SentinelTest extends PHPUnit_Framework_TestCase
             $users        = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository'),
             $roles        = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository'),
             $activations  = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository'),
-            $dispatcher   = m::mock('Illuminate\Events\Dispatcher')
+            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')
         );
 
         return [$sentinel, $persistences, $users, $roles, $activations, $dispatcher];


### PR DESCRIPTION
This commit will be fixed errors when Laravel mock events.