### PR TITLE
Issue #321: hotfix for issue in checkPermissin()

### DIFF
--- a/src/Permissions/PermissionsTrait.php
+++ b/src/Permissions/PermissionsTrait.php
@@ -200,8 +200,12 @@ trait PermissionsTrait
         if (array_key_exists($permission, $prepared) && $prepared[$permission] === true) {
             return true;
         }
-
+        //typecasted as a workaround for a flaw in laravel's str::is()
+        $permission = (string)$permission;
+        
         foreach ($prepared as $key => $value) {
+            //typecasted as a workaround for a flaw in laravel's str::is()
+            $key = (string)$key;            
             if ((str_is($permission, $key) || str_is($key, $permission)) && $value === true) {
                 return true;
             }


### PR DESCRIPTION
I have implemented a workaround to fix the issue. 

Its just a workaround for the issue but we can always redefine/override the str_is() but I was really unable to find where to put the overridden.