### PR TITLE
Bugfix: `get()` on `IlluminateCookie` returning incorrect type.

### DIFF
--- a/src/Cookies/IlluminateCookie.php
+++ b/src/Cookies/IlluminateCookie.php
@@ -22,7 +22,6 @@ namespace Cartalyst\Sentinel\Cookies;
 
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Cookie;
 
 class IlluminateCookie implements CookieInterface
 {

--- a/src/Cookies/IlluminateCookie.php
+++ b/src/Cookies/IlluminateCookie.php
@@ -87,7 +87,7 @@ class IlluminateCookie implements CookieInterface
         $queued = $this->jar->getQueuedCookies();
 
         if (isset($queued[$key])) {
-          return $queued[$key]->getValue();
+            return $queued[$key]->getValue();
         }
 
         return $this->request->cookie($key);

--- a/src/Cookies/IlluminateCookie.php
+++ b/src/Cookies/IlluminateCookie.php
@@ -22,6 +22,7 @@ namespace Cartalyst\Sentinel\Cookies;
 
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class IlluminateCookie implements CookieInterface
 {
@@ -86,11 +87,13 @@ class IlluminateCookie implements CookieInterface
         // available in 4.0.*, only 4.1+
         $queued = $this->jar->getQueuedCookies();
 
-        if (isset($queued[$key])) {
-            return $queued[$key];
+        $cookie = isset($queued[$key]) ? $queued[$key] : $this->request->cookie($key);
+
+        if ($cookie instanceof Cookie) {
+            return $cookie->getValue();
         }
 
-        return $this->request->cookie($key);
+        return $cookie;
     }
 
     /**

--- a/src/Cookies/IlluminateCookie.php
+++ b/src/Cookies/IlluminateCookie.php
@@ -87,13 +87,11 @@ class IlluminateCookie implements CookieInterface
         // available in 4.0.*, only 4.1+
         $queued = $this->jar->getQueuedCookies();
 
-        $cookie = isset($queued[$key]) ? $queued[$key] : $this->request->cookie($key);
-
-        if ($cookie instanceof Cookie) {
-            return $cookie->getValue();
+        if (isset($queued[$key])) {
+          return $queued[$key]->getValue();
         }
 
-        return $cookie;
+        return $this->request->cookie($key);
     }
 
     /**

--- a/tests/IlluminateCookieTest.php
+++ b/tests/IlluminateCookieTest.php
@@ -38,10 +38,10 @@ class IlluminateCookieTest extends PHPUnit_Framework_TestCase
 
     public function testPut()
     {
-        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
         $jar->shouldReceive('forever')->with('foo', 'bar')->once()->andReturn('cookie');
         $jar->shouldReceive('queue')->with('cookie')->once();
-        $illuminateCookie->put('bar');
+        $cookie->put('bar');
     }
 
     public function testGetWithQueuedCookie()
@@ -54,17 +54,17 @@ class IlluminateCookieTest extends PHPUnit_Framework_TestCase
 
     public function testGetWithPreviousCookies()
     {
-        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
         $jar->shouldReceive('getQueuedCookies')->once()->andReturn([]);
         $request->shouldReceive('cookie')->with('foo')->once()->andReturn('bar');
-        $this->assertEquals('bar', $illuminateCookie->get());
+        $this->assertEquals('bar', $cookie->get());
     }
 
     public function testForget()
     {
-        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
         $jar->shouldReceive('forget')->with('foo')->once()->andReturn('cookie');
         $jar->shouldReceive('queue')->with('cookie')->once();
-        $illuminateCookie->forget();
+        $cookie->forget();
     }
 }

--- a/tests/IlluminateCookieTest.php
+++ b/tests/IlluminateCookieTest.php
@@ -46,9 +46,10 @@ class IlluminateCookieTest extends PHPUnit_Framework_TestCase
 
     public function testGetWithQueuedCookie()
     {
-        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
-        $jar->shouldReceive('getQueuedCookies')->once()->andReturn(['foo' => 'bar']);
-        $this->assertEquals('bar', $cookie->get());
+        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $jar->shouldReceive('getQueuedCookies')->once()->andReturn(['foo' => $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie')]);
+        $cookie->shouldReceive('getValue')->andReturn('bar');
+        $this->assertEquals('bar', $illuminateCookie->get());
     }
 
     public function testGetWithPreviousCookies()

--- a/tests/IlluminateCookieTest.php
+++ b/tests/IlluminateCookieTest.php
@@ -38,10 +38,10 @@ class IlluminateCookieTest extends PHPUnit_Framework_TestCase
 
     public function testPut()
     {
-        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
         $jar->shouldReceive('forever')->with('foo', 'bar')->once()->andReturn('cookie');
         $jar->shouldReceive('queue')->with('cookie')->once();
-        $cookie->put('bar');
+        $illuminateCookie->put('bar');
     }
 
     public function testGetWithQueuedCookie()
@@ -54,17 +54,17 @@ class IlluminateCookieTest extends PHPUnit_Framework_TestCase
 
     public function testGetWithPreviousCookies()
     {
-        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
         $jar->shouldReceive('getQueuedCookies')->once()->andReturn([]);
         $request->shouldReceive('cookie')->with('foo')->once()->andReturn('bar');
-        $this->assertEquals('bar', $cookie->get());
+        $this->assertEquals('bar', $illuminateCookie->get());
     }
 
     public function testForget()
     {
-        $cookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
+        $illuminateCookie = new IlluminateCookie($request = m::mock('Illuminate\Http\Request'), $jar = m::mock('Illuminate\Cookie\CookieJar'), 'foo');
         $jar->shouldReceive('forget')->with('foo')->once()->andReturn('cookie');
         $jar->shouldReceive('queue')->with('cookie')->once();
-        $cookie->forget();
+        $illuminateCookie->forget();
     }
 }


### PR DESCRIPTION
    - `Illumate\Cookie\CookieJar` contains `Cookie` objects, not string values.
    - The return value of `get()` is expected to be string.
    - Return the string value from `Cookie` objects instead of the `Cookie` itself.