### PR TITLE
Fix force deletion of users

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -410,7 +410,8 @@ class EloquentUser extends Model implements RoleableInterface, PermissibleInterf
      */
     public function delete()
     {
-        $isSoftDeleted = array_key_exists('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this));
+        $isSoftDeletable = property_exists($this, 'forceDeleting');
+        $isSoftDeleted = $isSoftDeletable && !$this->forceDeleting;
 
         if ($this->exists && ! $isSoftDeleted) {
             $this->activations()->delete();


### PR DESCRIPTION
Simply having the SoftDelete trait is not enough to determine that
we're soft deleting, because the forceDelete() method will perform a
proper hard delete.

However, this will fail because there could still be roles referring
to the user object, resulting in a constraint violation.