### PR TITLE
Eliminate need for Instance of Dispatcher in Sentinel constructor

### DIFF
--- a/src/Laravel/SentinelServiceProvider.php
+++ b/src/Laravel/SentinelServiceProvider.php
@@ -308,9 +308,10 @@ class SentinelServiceProvider extends ServiceProvider
                 $app['sentinel.persistence'],
                 $app['sentinel.users'],
                 $app['sentinel.roles'],
-                $app['sentinel.activations'],
-                $app['events']
+                $app['sentinel.activations']
             );
+
+            $sentinel->setDispatcher($app['events']);
 
             if (isset($app['sentinel.checkpoints'])) {
                 foreach ($app['sentinel.checkpoints'] as $key => $checkpoint) {

--- a/src/Native/SentinelBootstrapper.php
+++ b/src/Native/SentinelBootstrapper.php
@@ -84,9 +84,10 @@ class SentinelBootstrapper
             $persistence,
             $users,
             $roles,
-            $activations,
-            $dispatcher
+            $activations
         );
+
+        $sentinel->setDispatcher($dispatcher);
 
         $throttle = $this->createThrottling();
 

--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -31,7 +31,6 @@ use Cartalyst\Sentinel\Users\UserInterface;
 use Cartalyst\Sentinel\Users\UserRepositoryInterface;
 use Cartalyst\Support\Traits\EventTrait;
 use Closure;
-use Illuminate\Contracts\Events\Dispatcher;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -130,15 +129,13 @@ class Sentinel
      * @param  \Cartalyst\Sentinel\Users\UserRepositoryInterface  $users
      * @param  \Cartalyst\Sentinel\Roles\RoleRepositoryInterface  $roles
      * @param  \Cartalyst\Sentinel\Activations\ActivationRepositoryInterface  $activations
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @return void
      */
     public function __construct(
         PersistenceRepositoryInterface $persistences,
         UserRepositoryInterface $users,
         RoleRepositoryInterface $roles,
-        ActivationRepositoryInterface $activations,
-        Dispatcher $dispatcher
+        ActivationRepositoryInterface $activations
     ) {
         $this->persistences = $persistences;
 
@@ -147,8 +144,6 @@ class Sentinel
         $this->roles = $roles;
 
         $this->activations = $activations;
-
-        $this->dispatcher = $dispatcher;
     }
 
     /**

--- a/tests/CheckpointsTest.php
+++ b/tests/CheckpointsTest.php
@@ -218,9 +218,10 @@ class CheckpointsTest extends PHPUnit_Framework_TestCase
             $persistences = m::mock('Cartalyst\Sentinel\Persistences\PersistenceRepositoryInterface'),
             $users        = m::mock('Cartalyst\Sentinel\Users\UserRepositoryInterface'),
             $roles        = m::mock('Cartalyst\Sentinel\Roles\RoleRepositoryInterface'),
-            $activations  = m::mock('Cartalyst\Sentinel\Activations\ActivationRepositoryInterface'),
-            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')
+            $activations  = m::mock('Cartalyst\Sentinel\Activations\ActivationRepositoryInterface')
         );
+
+        $sentinel->setDispatcher($dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher'));
 
         $throttle = m::mock('Cartalyst\Sentinel\Throttling\ThrottleRepositoryInterface');
 

--- a/tests/SentinelTest.php
+++ b/tests/SentinelTest.php
@@ -524,9 +524,10 @@ class SentinelTest extends PHPUnit_Framework_TestCase
             $persistences = m::mock('Cartalyst\Sentinel\Persistences\IlluminatePersistenceRepository'),
             $users        = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository'),
             $roles        = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository'),
-            $activations  = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository'),
-            $dispatcher   = m::mock('Illuminate\Contracts\Events\Dispatcher')
+            $activations  = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository')
         );
+
+        $sentinel->setDispatcher($dispatcher = m::mock('Illuminate\Contracts\Events\Dispatcher'));
 
         return [$sentinel, $persistences, $users, $roles, $activations, $dispatcher];
     }


### PR DESCRIPTION
This change renders the dispatcher completely optional. Otherwise the Packagist package dependency to illuminate/events should be "requires" not "requires(dev)" because there is no way to use Sentinel without it.