### PR TITLE
Fix: Update create docblock

### DIFF
--- a/src/Reminders/ReminderRepositoryInterface.php
+++ b/src/Reminders/ReminderRepositoryInterface.php
@@ -28,7 +28,7 @@ interface ReminderRepositoryInterface
      * Create a new reminder record and code.
      *
      * @param  \Cartalyst\Sentinel\Users\UserInterface  $user
-     * @return string
+     * @return mixed
      */
     public function create(UserInterface $user);
 


### PR DESCRIPTION
The docblock was incorrect, since the implementation did not return a string, but a Model. Since reminders don't have their own interface, it now simply returns mixed, as to not confuse IDEs.

As mentioned in #402 