### PR TITLE
Updated `orWhere` query builder loop to lead with correct boolean constraint.

### DIFF
--- a/src/Users/IlluminateUserRepository.php
+++ b/src/Users/IlluminateUserRepository.php
@@ -106,8 +106,10 @@ class IlluminateUserRepository implements UserRepositoryInterface
             }
         } else {
             $query->whereNested(function ($query) use ($loginNames, $logins) {
-                foreach ($loginNames as $name) {
-                    $query->orWhere($name, $logins);
+                foreach ($loginNames as $index => $name) {
+                    // Only use OR after the first iteration so that the query is built using the correct boolean logic.
+                    $whereMethod = $index === 0 ? 'where' : 'orWhere';
+                    $query->$whereMethod($name, $logins);
                 }
             });
         }


### PR DESCRIPTION
With Laravel 5.3, the leading boolean of Eloquent scope constraints are now respected. Therefore, the new behavior does not convert the first call to `orWhere` to `where`. See "Eloquent Scopes" at https://laravel.com/docs/5.3/upgrade#upgrade-5.3.0 .