### PR TITLE
Update SentinelServiceProvider.php

### DIFF
--- a/src/Laravel/SentinelServiceProvider.php
+++ b/src/Laravel/SentinelServiceProvider.php
@@ -44,6 +44,7 @@ class SentinelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->setOverrides();
         $this->garbageCollect();
     }
 
@@ -53,7 +54,6 @@ class SentinelServiceProvider extends ServiceProvider
     public function register()
     {
         $this->prepareResources();
-        $this->setOverrides();
         $this->registerPersistences();
         $this->registerUsers();
         $this->registerRoles();


### PR DESCRIPTION
The `setOverrides()` method should be called on `boot()`.

From Laravel Docs under "**The Register Method**":
> As mentioned previously, within the register method, you should only bind things into the service container. You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method.

The `setOverrides()` calls other methods to set the Sentinel models, and doesn't actually have anything to do with server container bindings. This can cause obscure issues.

For more information, refer to this [pull request](https://github.com/orchestral/testbench-core/pull/17).