### PR TITLE
Improve Tests

### DIFF
--- a/tests/EloquentRoleTest.php
+++ b/tests/EloquentRoleTest.php
@@ -70,6 +70,8 @@ class EloquentRoleTest extends PHPUnit_Framework_TestCase
         $role = m::mock('Cartalyst\Sentinel\Roles\EloquentRole[users]');
         $role->exists = true;
 
+        $this->addMockConnection($role);
+
         $role->getConnection()->getQueryGrammar()->shouldReceive('compileDelete');
         $role->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForDelete')->andReturn([]);
         $role->getConnection()->shouldReceive('delete')->once();

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -259,6 +259,8 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $user = new EloquentUser;
 
         $this->addMockConnection($user);
+        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([]);
+        $user->getConnection()->shouldReceive('select');
         $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
 
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->getRoles());

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -155,12 +155,16 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
     {
         $user = new EloquentUser;
 
+        $this->addMockConnection($user);
+
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Relations\BelongsToMany', $user->roles());
     }
 
     public function testPersistencesRelationship()
     {
         $user = new EloquentUser;
+
+        $this->addMockConnection($user);
 
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Relations\HasMany', $user->persistences());
     }
@@ -253,6 +257,8 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
     public function testGetRoles()
     {
         $user = new EloquentUser;
+
+        $this->addMockConnection($user);
 
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->getRoles());
     }

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -102,14 +102,11 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
     {
         $user = new EloquentUser;
 
-        $user->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $this->addMockConnection($user);
         $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $user->getConnection()->shouldReceive('getPostProcessor')->andReturn($processor = m::mock('Illuminate\Database\Query\Processors\Processor'));
         $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $processor->shouldReceive('processInsertGetId')->andReturn(1);
+        $user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
 
         $user->save();
 
@@ -122,14 +119,11 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $user = new EloquentUser;
         $user->email = 'foo@example.com';
 
-        $user->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $this->addMockConnection($user);
         $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $user->getConnection()->shouldReceive('getPostProcessor')->andReturn($processor = m::mock('Illuminate\Database\Query\Processors\Processor'));
         $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $processor->shouldReceive('processInsertGetId')->andReturn(1);
+        $user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
 
         $user->save();
 
@@ -176,14 +170,11 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $user = new EloquentUser;
         $user->id = 0;
 
-        $user->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $this->addMockConnection($user);
         $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $user->getConnection()->shouldReceive('getPostProcessor')->andReturn($processor = m::mock('Illuminate\Database\Query\Processors\Processor'));
         $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $processor->shouldReceive('processSelect')->andReturn([
+        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
             [
                 'slug' => 'foobar',
             ],
@@ -209,14 +200,11 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $user = new EloquentUser;
         $user->id = 0;
 
-        $user->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $this->addMockConnection($user);
         $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $user->getConnection()->shouldReceive('getPostProcessor')->andReturn($processor = m::mock('Illuminate\Database\Query\Processors\Processor'));
         $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $processor->shouldReceive('processSelect')->andReturn([
+        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
             [
                 'id'   => 1,
                 'slug' => 'foobar',
@@ -274,6 +262,7 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $user = m::mock('Cartalyst\Sentinel\Users\EloquentUser[roles,persistences,activations,reminders,throttle]');
         $user->exists = true;
 
+        $this->addMockConnection($user);
         $user->getConnection()->getQueryGrammar()->shouldReceive('compileDelete');
         $user->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForDelete')->andReturn([]);
         $user->getConnection()->shouldReceive('delete')->once();
@@ -299,5 +288,13 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $throttle->shouldReceive('delete')->once();
 
         $user->delete();
+    }
+
+    protected function addMockConnection($model)
+    {
+        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
     }
 }

--- a/tests/EloquentUserTest.php
+++ b/tests/EloquentUserTest.php
@@ -259,6 +259,7 @@ class EloquentUserTest extends PHPUnit_Framework_TestCase
         $user = new EloquentUser;
 
         $this->addMockConnection($user);
+        $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
 
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->getRoles());
     }

--- a/tests/IlluminateActivationRepositoryTest.php
+++ b/tests/IlluminateActivationRepositoryTest.php
@@ -47,6 +47,8 @@ class IlluminateActivationRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($activations, $model, $query) = $this->getActivationMock();
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
 
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
@@ -192,5 +194,14 @@ class IlluminateActivationRepositoryTest extends PHPUnit_Framework_TestCase
             $this->assertEquals(time() - $expires, $timestamp->getTimestamp(), '', 3);
             return true;
         }))->andReturn($query);
+    }
+
+
+    protected function addMockConnection($model)
+    {
+        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
     }
 }

--- a/tests/IlluminateReminderRepositoryTest.php
+++ b/tests/IlluminateReminderRepositoryTest.php
@@ -49,6 +49,8 @@ class IlluminateReminderRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($reminders, $users, $model, $query) = $this->getReminderMock();
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
 
@@ -175,5 +177,13 @@ class IlluminateReminderRepositoryTest extends PHPUnit_Framework_TestCase
             $this->assertEquals(time() - $expires, $timestamp->getTimestamp(), '', 3);
             return true;
         }))->andReturn($query);
+    }
+
+    protected function addMockConnection($model)
+    {
+        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
     }
 }

--- a/tests/IlluminateThrottleRepositoryTest.php
+++ b/tests/IlluminateThrottleRepositoryTest.php
@@ -60,6 +60,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setGlobalThresholds(5);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
@@ -85,6 +86,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setGlobalThresholds(200);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
@@ -110,6 +112,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setGlobalThresholds([5 => 3, 10 => 10]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
@@ -135,6 +138,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setGlobalThresholds([5 => 3, 10 => 10]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
@@ -160,6 +164,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setGlobalThresholds([5 => 33, 10 => 100]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
@@ -185,6 +190,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setIpThresholds(5);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'ip')->andReturn($query);
         $query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($query);
@@ -211,6 +217,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setIpThresholds([5 => 3, 10 => 10]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'ip')->andReturn($query);
         $query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($query);
@@ -237,6 +244,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setIpThresholds([5 => 3, 10 => 10]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'ip')->andReturn($query);
         $query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($query);
@@ -263,6 +271,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setUserThresholds(5);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'user')->andReturn($query);
         $query->shouldReceive('where')->with('user_id', 1)->andReturn($query);
@@ -292,6 +301,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setUserThresholds([5 => 3, 10 => 10]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'user')->andReturn($query);
         $query->shouldReceive('where')->with('user_id', 1)->andReturn($query);
@@ -321,6 +331,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $throttle->setUserThresholds([5 => 3, 10 => 10]);
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        $this->addMockConnection($model);
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'user')->andReturn($query);
         $query->shouldReceive('where')->with('user_id', 1)->andReturn($query);
@@ -349,19 +360,31 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
         $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
 
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
         $query->shouldReceive('where')->with('id', '=', '');
 
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
-        $model->getConnection()->getQueryGrammar()->shouldReceive('compileUpdate')->once();
-        $model->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForUpdate')->once()->andReturn([]);
-        $model->getConnection()->shouldReceive('update')->once();
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileUpdate')->twice();
+        $model->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForUpdate')->twice()->andReturn([]);
+        $model->getConnection()->shouldReceive('update')->twice();
 
         $user = m::mock('Cartalyst\Sentinel\Users\EloquentUser');
         $user->shouldReceive('getUserId')->once()->andReturn(1);
 
         $throttle->log('127.0.0.1', $user);
+    }
+
+    protected function addMockConnection($model)
+    {
+        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
     }
 }

--- a/tests/IlluminateThrottleRepositoryTest.php
+++ b/tests/IlluminateThrottleRepositoryTest.php
@@ -53,15 +53,13 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGlobalDelayWithIntegerThreshold1()
     {
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $startTime = time();
 
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
         $throttle->setGlobalInterval(10);
         $throttle->setGlobalThresholds(5);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
         $query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
@@ -81,13 +79,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGlobalDelayWithIntegerThreshold2()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setGlobalInterval(10);
         $throttle->setGlobalThresholds(200);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
         $query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
@@ -107,13 +103,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGlobalDelayWithArrayThresholds1()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setGlobalInterval(10);
         $throttle->setGlobalThresholds([5 => 3, 10 => 10]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
         $query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
@@ -133,13 +127,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGlobalDelayWithArrayThresholds2()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setGlobalInterval(10);
         $throttle->setGlobalThresholds([5 => 3, 10 => 10]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
         $query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
@@ -159,13 +151,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testGlobalDelayWithArrayThresholds3()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setGlobalInterval(10);
         $throttle->setGlobalThresholds([5 => 33, 10 => 100]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
 
         $query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
@@ -185,13 +175,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testIpDelayWithIntegerThreshold()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setIpInterval(10);
         $throttle->setIpThresholds(5);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'ip')->andReturn($query);
         $query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($query);
 
@@ -212,13 +200,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testIpDelayWithArrayThresholds1()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setIpInterval(10);
         $throttle->setIpThresholds([5 => 3, 10 => 10]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'ip')->andReturn($query);
         $query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($query);
 
@@ -239,13 +225,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testIpDelayWithArrayThresholds2()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setIpInterval(10);
         $throttle->setIpThresholds([5 => 3, 10 => 10]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'ip')->andReturn($query);
         $query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($query);
 
@@ -266,13 +250,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testUserDelayWithIntegerThreshold()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setUserInterval(10);
         $throttle->setUserThresholds(5);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'user')->andReturn($query);
         $query->shouldReceive('where')->with('user_id', 1)->andReturn($query);
 
@@ -296,13 +278,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testUserDelayWithArrayThresholds1()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setUserInterval(10);
         $throttle->setUserThresholds([5 => 3, 10 => 10]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'user')->andReturn($query);
         $query->shouldReceive('where')->with('user_id', 1)->andReturn($query);
 
@@ -326,13 +306,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testUserDelayWithArrayThresholds2()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
+        list($throttle, $model, $query) = $this->getThrottlingMock();
         $throttle->setUserInterval(10);
         $throttle->setUserThresholds([5 => 3, 10 => 10]);
 
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
         $this->addMockConnection($model);
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
         $query->shouldReceive('where')->with('type', 'user')->andReturn($query);
         $query->shouldReceive('where')->with('user_id', 1)->andReturn($query);
 
@@ -356,15 +334,11 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testLog()
     {
-        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]');
-
-        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+        list($throttle, $model, $query) = $this->getThrottlingMock();
 
         $this->addMockConnection($model);
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
 
         $query->shouldReceive('where')->with('type', 'global')->andReturn($query);
         $query->shouldReceive('where')->with('id', '=', '');
@@ -378,6 +352,18 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
         $user->shouldReceive('getUserId')->once()->andReturn(1);
 
         $throttle->log('127.0.0.1', $user);
+    }
+
+    protected function getThrottlingMock()
+    {
+        $users     = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository');
+        $throttle = m::mock('Cartalyst\Sentinel\Throttling\IlluminateThrottleRepository[createModel]', [$users]);
+
+        $throttle->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle[newQuery]'));
+
+        $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
+
+        return [$throttle, $model, $query];
     }
 
     protected function addMockConnection($model)

--- a/tests/IlluminateThrottleRepositoryTest.php
+++ b/tests/IlluminateThrottleRepositoryTest.php
@@ -345,7 +345,7 @@ class IlluminateThrottleRepositoryTest extends PHPUnit_Framework_TestCase
 
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
         $model->getConnection()->getQueryGrammar()->shouldReceive('compileUpdate')->twice();
-        $model->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForUpdate')->twice()->andReturn([]);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForUpdate')->andReturn([]);
         $model->getConnection()->shouldReceive('update')->twice();
 
         $user = m::mock('Cartalyst\Sentinel\Users\EloquentUser');

--- a/tests/IlluminateUserRepositoryTest.php
+++ b/tests/IlluminateUserRepositoryTest.php
@@ -137,6 +137,8 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($users, $hasher, $model, $query) = $this->getUsersMock();
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
 
@@ -147,6 +149,8 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($users, $hasher, $model, $query) = $this->getUsersMock();
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
 
@@ -254,6 +258,8 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($users, $hasher, $model, $query) = $this->getUsersMock();
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
 
@@ -271,6 +277,8 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($users, $hasher, $model, $query) = $this->getUsersMock();
 
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
 
@@ -290,6 +298,7 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($users, $hasher, $model, $query) = $this->getUsersMock();
 
+        $this->addMockConnection($model);
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
 
         $hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
@@ -308,15 +317,12 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         list($users, $hasher, $model, $query) = $this->getUsersMock();
 
-        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
-        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $this->addMockConnection($model);
         $model->getConnection()->shouldReceive('getName');
-        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
-        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn($processor = m::mock('Illuminate\Database\Query\Processors\Processor'));
 
         $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $processor->shouldReceive('processInsertGetId');
+        $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId');
 
         $user = $this->fakeUser();
 
@@ -335,6 +341,10 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
 
         $users->shouldReceive('findById')->once()->andReturn($user = $this->fakeUser());
         $users->shouldReceive('createModel')->andReturn($model = m::mock('Cartalyst\Sentinel\Users\EloquentUser[newQuery]'));
+        $this->addMockConnection($model);
+        $model->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $model->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $model->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->once();
 
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
 
@@ -377,5 +387,13 @@ class IlluminateUserRepositoryTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('newQuery')->andReturn($query = m::mock('Illuminate\Database\Eloquent\Builder'));
 
         return [$users, $hasher, $model, $query];
+    }
+
+    protected function addMockConnection($model)
+    {
+        $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+        $resolver->shouldReceive('connection')->andReturn(m::mock('Illuminate\Database\Connection')->makePartial());
+        $model->getConnection()->shouldReceive('getQueryGrammar')->andReturn(m::mock('Illuminate\Database\Query\Grammars\Grammar'));
+        $model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
     }
 }


### PR DESCRIPTION
Currently some of the tests cant be ran individually i.e: 

running ```vendor/bin/phpunit``` all tests pass. 

running ``` vendor/bin/phpunit tests/IlluminateActivationRepositoryTests.php``` fails with ```1) Cartalyst\Sentinel\tests\IlluminateActivationRepositoryTest::testCreate
Error: Call to a member function connection() on null```

As far as i can tell, this is because the mocked connection is used from the previous tests rather than the test building it's own mocks. I'm not sure if this is a problem with mockery not closing down correctly?

However this also removes the dependency of other tests passing from most tests. Meaning all tests will run irrelevant of any other test status. Where as previously if some tests failed this could cause other tests to fail.

Ive also modified the throttling tests to match that of the others with the ```addThrottlingMock``` method