### PR TITLE
Activations Checkpoint missing return

### DIFF
--- a/src/Checkpoints/ActivationCheckpoint.php
+++ b/src/Checkpoints/ActivationCheckpoint.php
@@ -79,5 +79,7 @@ class ActivationCheckpoint implements CheckpointInterface
 
             throw $exception;
         }
+
+        return $completed;
     }
 }


### PR DESCRIPTION
While sorting out the tests for this project i came across this. turns out ```ActivationCheckpoint::login```
or ```ActivationCheckpoint::check``` would never return the value stated in the docs and instead would always return ```null```.
I think the only place this is used is [here] (https://github.com/cartalyst/sentinel/blob/36d802f962dc14f7c0639a94976892fa0708dc23/src/Sentinel.php#L252) and !null will always return true. however i've only had a quick look to see what might be affected by this.