### PR TITLE
fix docblock return value of logout function

### DIFF
--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -536,7 +536,7 @@ class Sentinel
      * @param \Cartalyst\Sentinel\Users\UserInterface|null $user
      * @param bool                                         $everywhere
      *
-     * @return bool
+     * @return \Cartalyst\Sentinel\Users\UserInterface|bool
      */
     public function logout(UserInterface $user = null, bool $everywhere = false): bool
     {


### PR DESCRIPTION
sentinel returns ```IlluminateUserRepository::recordLogout``` in the logout function which can return the user on failure.
https://github.com/cartalyst/sentinel/blob/d1e5d6c2afab33134c70eac1962aed769ddc3077/src/Users/UserRepositoryInterface.php#L59-L65
