### PR TITLE
remove redundant is_array check

### DIFF
--- a/src/Users/IlluminateUserRepository.php
+++ b/src/Users/IlluminateUserRepository.php
@@ -93,18 +93,8 @@ class IlluminateUserRepository implements UserRepositoryInterface
 
         $query = $instance->newQuery();
 
-        if (is_array($logins)) {
-            foreach ($logins as $key => $value) {
-                $query->where($key, $value);
-            }
-        } else {
-            $query->whereNested(function ($query) use ($loginNames, $logins) {
-                foreach ($loginNames as $index => $name) {
-                    $method = $index === 0 ? 'where' : 'orWhere';
-
-                    $query->{$method}($name, $logins);
-                }
-            });
+        foreach ($logins as $key => $value) {
+            $query->where($key, $value);
         }
 
         return $query->first();
@@ -232,15 +222,7 @@ class IlluminateUserRepository implements UserRepositoryInterface
 
         list($logins, $password, $attributes) = $this->parseCredentials($credentials, $loginNames);
 
-        if (is_array($logins)) {
-            $user->fill($logins);
-        } else {
-            $loginName = reset($loginNames);
-
-            $user->fill([
-                $loginName => $logins,
-            ]);
-        }
+        $user->fill($logins);
 
         $user->fill($attributes);
 


### PR DESCRIPTION
bit of a weird one this one. i cant really figure out the logic behind this although i havent delved too far in. it looks to me like ```IlluminateUserRepository::paerseCredentials``` will never return ```logins``` as anything other than an array so checking its an array doesn't have much point. although i could have completely missed something.

https://github.com/cartalyst/sentinel/blob/401d36a10dcf0fa8dfb566fe5860166fba68274b/src/Users/IlluminateUserRepository.php#L290-L317