### PR TITLE
make personal permissions take priority over pattern matching

### DIFF
--- a/src/Permissions/PermissionsTrait.php
+++ b/src/Permissions/PermissionsTrait.php
@@ -202,11 +202,9 @@ trait PermissionsTrait
      */
     protected function checkPermission(array $prepared, string $permission): bool
     {
-        if (array_key_exists($permission, $prepared) && $prepared[$permission] === true) {
-            return true;
+        if (array_key_exists($permission, $prepared)) {
+            return $prepared[$permission] === true;
         }
-
-        $permission = (string) $permission;
 
         foreach ($prepared as $key => $value) {
             $key = (string) $key;

--- a/tests/Permissions/PermissionsTraitTest.php
+++ b/tests/Permissions/PermissionsTraitTest.php
@@ -82,6 +82,19 @@ class PermissionsTraitTest extends TestCase
     }
 
     /** @test */
+    public function personal_permissions_take_priority_over_pattern_match()
+    {
+        $permissions = new PermissionsStub([
+            'user.*'    => true,
+            'user.delete' => false,
+        ]);
+
+        $this->assertTrue($permissions->hasAccess('user.*'));
+        $this->assertTrue($permissions->hasAccess('user.test'));
+        $this->assertFalse($permissions->hasAccess('user.delete'));
+    }
+
+    /** @test */
     public function permissions_as_class_names_can_be_used()
     {
         $permissions = new PermissionsStub([


### PR DESCRIPTION
the string typecast has been removed as we now have typehinting on the parameters.

I think it would make more sense to just ```return $prepared[$permission]``` however we cannot be certain of this variable as far as i'm aware so i think evaluating to true this is the better alternative at the moment.

Closes #244 