### PR TITLE
Fix issue for Throttling not being set

### DIFF
--- a/src/Laravel/SentinelServiceProvider.php
+++ b/src/Laravel/SentinelServiceProvider.php
@@ -332,6 +332,7 @@ class SentinelServiceProvider extends ServiceProvider
 
             $sentinel->setActivationRepository($app['sentinel.activations']);
             $sentinel->setReminderRepository($app['sentinel.reminders']);
+            $sentinel->setThrottleRepository($app['sentinel.throttling']);
 
             $sentinel->setRequestCredentials(function () use ($app) {
                 $request = $app['request'];


### PR DESCRIPTION
seems like this was just forgotten i think as its in the ```Native\SentinelBootstrapper```

https://github.com/cartalyst/sentinel/blob/0d6f69e405cc4c907f5f7944d9b4c0c2bb5a20f6/src/Native/SentinelBootstrapper.php#L103-L107

Fixes: #444 