### PR TITLE
better use of test setUp methods

### DIFF
--- a/tests/Activations/EloquentActivationTest.php
+++ b/tests/Activations/EloquentActivationTest.php
@@ -47,6 +47,7 @@ class EloquentActivationTest extends TestCase
     protected function tearDown(): void
     {
         $this->activation = null;
+
         m::close();
     }
 

--- a/tests/Activations/EloquentActivationTest.php
+++ b/tests/Activations/EloquentActivationTest.php
@@ -27,30 +27,42 @@ use Cartalyst\Sentinel\Activations\EloquentActivation;
 class EloquentActivationTest extends TestCase
 {
     /**
+     * The Activation Eloquent instance.
+     *
+     * @var \Cartalyst\Sentinel\Activations\EloquentActivation
+     */
+    protected $activation;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->activation = new EloquentActivation();
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function tearDown(): void
     {
+        $this->activation = null;
         m::close();
     }
 
     /** @test */
     public function it_can_get_the_completed_attribute_as_a_boolean()
     {
-        $activation = new EloquentActivation();
+        $this->activation->completed = 1;
 
-        $activation->completed = 1;
-
-        $this->assertTrue($activation->completed);
+        $this->assertTrue($this->activation->completed);
     }
 
     /** @test */
     public function it_can_get_the_activation_code_using_the_getter()
     {
-        $activation = new EloquentActivation();
+        $this->activation->code = 'foo';
 
-        $activation->code = 'foo';
-
-        $this->assertSame('foo', $activation->getCode());
+        $this->assertSame('foo', $this->activation->getCode());
     }
 }

--- a/tests/Activations/IlluminateActivationRepositoryTest.php
+++ b/tests/Activations/IlluminateActivationRepositoryTest.php
@@ -51,6 +51,9 @@ class IlluminateActivationRepositoryTest extends TestCase
      */
     protected $query;
 
+    /**
+     * {@inheritdoc}
+     */
     protected function setUp(): void
     {
         $this->query = m::mock(Builder::class);
@@ -70,6 +73,7 @@ class IlluminateActivationRepositoryTest extends TestCase
         $this->query       = null;
         $this->model       = null;
         $this->activations = null;
+
         m::close();
     }
 

--- a/tests/Activations/IlluminateActivationRepositoryTest.php
+++ b/tests/Activations/IlluminateActivationRepositoryTest.php
@@ -31,10 +31,45 @@ use Cartalyst\Sentinel\Activations\IlluminateActivationRepository;
 class IlluminateActivationRepositoryTest extends TestCase
 {
     /**
+     * The Activations repository instance.
+     *
+     * @var \Cartalyst\Sentinel\Activations\ActivationRepositoryInterface
+     */
+    protected $activations;
+
+    /**
+     * The Eloquent Activation instance.
+     *
+     * @var \Cartalyst\Sentinel\Activations\EloquentActivation
+     */
+    protected $model;
+
+    /**
+     * The Builder Instance.
+     *
+     * @var \Illuminate\Database\Eloquent\Builder;
+     */
+    protected $query;
+
+    protected function setUp(): void
+    {
+        $this->query = m::mock(Builder::class);
+
+        $this->model = m::mock(EloquentActivation::class);
+        $this->model->shouldReceive('newQuery')->andReturn($this->query);
+
+        $this->activations = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository[createModel]', ['ActivationModelMock', 259200]);
+        $this->activations->shouldReceive('createModel')->andReturn($this->model);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function tearDown(): void
     {
+        $this->query       = null;
+        $this->model       = null;
+        $this->activations = null;
         m::close();
     }
 
@@ -49,15 +84,13 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_create_an_activation_code()
     {
-        [$activations, $model] = $this->getActivationMock();
-
-        $model->shouldReceive('fill');
-        $model->shouldReceive('setAttribute');
-        $model->shouldReceive('save');
+        $this->model->shouldReceive('fill');
+        $this->model->shouldReceive('setAttribute');
+        $this->model->shouldReceive('save');
 
         $user = $this->getUserMock();
 
-        $activation = $activations->create($user);
+        $activation = $this->activations->create($user);
 
         $this->assertInstanceOf(EloquentActivation::class, $activation);
     }
@@ -65,22 +98,19 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_determine_if_an_activation_exists()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', false)->andReturnSelf();
+        $this->query->shouldReceive('where')->with('created_at', '>', m::type(Carbon::class))->andReturnSelf();
+        $this->query->shouldReceive('when')->with('foo', m::on(function ($argument) {
+            $this->query->shouldReceive('where')->with('code', 'bar')->andReturn(true);
 
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', false)->andReturn($query);
-        $query->shouldReceive('when')->with('foo', m::on(function ($argument) use ($query) {
-            $query->shouldReceive('where')->with('code', 'bar')->andReturn(true);
-
-            return $argument($query, 'bar') == $query;
-        }))->andReturn($query);
-        $query->shouldReceive('first')->once();
-
-        $this->shouldReceiveExpires($query);
+            return $argument($this->query, 'bar') == $this->query;
+        }))->andReturnSelf();
+        $this->query->shouldReceive('first')->once();
 
         $user = $this->getUserMock();
 
-        $status = $activations->exists($user, 'foo');
+        $status = $this->activations->exists($user, 'foo');
 
         $this->assertFalse($status);
     }
@@ -88,22 +118,19 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_complete_an_activation()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
-
         $activation = m::mock(EloquentActivation::class);
         $activation->shouldReceive('fill')->once();
         $activation->shouldReceive('save')->once();
 
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('code', 'foobar')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', false)->andReturn($query);
-        $query->shouldReceive('first')->once()->andReturn($activation);
-
-        $this->shouldReceiveExpires($query);
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('code', 'foobar')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', false)->andReturnSelf();
+        $this->query->shouldReceive('where')->with('created_at', '>', m::type(Carbon::class))->andReturnSelf();
+        $this->query->shouldReceive('first')->once()->andReturn($activation);
 
         $user = $this->getUserMock();
 
-        $status = $activations->complete($user, 'foobar');
+        $status = $this->activations->complete($user, 'foobar');
 
         $this->assertTrue($status);
     }
@@ -111,18 +138,15 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_cannot_complete_an_activation_that_has_expired()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
-
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('code', 'foobar')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', false)->andReturn($query);
-        $query->shouldReceive('first')->once();
-
-        $this->shouldReceiveExpires($query);
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('code', 'foobar')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', false)->andReturnSelf();
+        $this->query->shouldReceive('where')->with('created_at', '>', m::type(Carbon::class))->andReturnSelf();
+        $this->query->shouldReceive('first')->once();
 
         $user = $this->getUserMock();
 
-        $status = $activations->complete($user, 'foobar');
+        $status = $this->activations->complete($user, 'foobar');
 
         $this->assertFalse($status);
     }
@@ -130,15 +154,13 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_determine_if_an_activation_is_completed()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
-
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', true)->andReturn($query);
-        $query->shouldReceive('exists')->once()->andReturn(true);
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', true)->andReturnSelf();
+        $this->query->shouldReceive('exists')->once()->andReturn(true);
 
         $user = $this->getUserMock();
 
-        $status = $activations->completed($user);
+        $status = $this->activations->completed($user);
 
         $this->assertTrue($status);
     }
@@ -146,15 +168,13 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_determine_if_an_activation_is_not_completed()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
-
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', true)->andReturn($query);
-        $query->shouldReceive('exists')->once()->andReturn(false);
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', true)->andReturnSelf();
+        $this->query->shouldReceive('exists')->once()->andReturn(false);
 
         $user = $this->getUserMock();
 
-        $status = $activations->completed($user);
+        $status = $this->activations->completed($user);
 
         $this->assertFalse($status);
     }
@@ -162,15 +182,13 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_remove_non_completed_activations()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
-
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', true)->andReturn($query);
-        $query->shouldReceive('first')->once()->andReturn(false);
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', true)->andReturnSelf();
+        $this->query->shouldReceive('first')->once()->andReturn(false);
 
         $user = $this->getUserMock();
 
-        $status = $activations->remove($user);
+        $status = $this->activations->remove($user);
 
         $this->assertFalse($status);
     }
@@ -178,19 +196,17 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_remove_completed_activations()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
-
         $activation = m::mock(EloquentActivation::class);
 
-        $query->shouldReceive('where')->with('user_id', '1')->andReturn($query);
-        $query->shouldReceive('where')->with('completed', true)->andReturn($query);
-        $query->shouldReceive('first')->once()->andReturn($activation);
+        $this->query->shouldReceive('where')->with('user_id', '1')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('completed', true)->andReturnSelf();
+        $this->query->shouldReceive('first')->once()->andReturn($activation);
 
         $activation->shouldReceive('delete')->once()->andReturn(true);
 
         $user = $this->getUserMock();
 
-        $status = $activations->remove($user);
+        $status = $this->activations->remove($user);
 
         $this->assertTrue($status);
     }
@@ -198,30 +214,14 @@ class IlluminateActivationRepositoryTest extends TestCase
     /** @test */
     public function it_can_remove_expired_activations()
     {
-        [$activations, $model, $query] = $this->getActivationMock();
+        $this->query->shouldReceive('where')->with('completed', false)->andReturnSelf();
+        $this->query->shouldReceive('where')->with('created_at', '<', m::type(Carbon::class))->andReturnSelf();
 
-        $query->shouldReceive('where')->with('completed', false)->andReturn($query);
+        $this->query->shouldReceive('delete')->once()->andReturn(true);
 
-        $this->shouldReceiveExpires($query, '<');
-
-        $query->shouldReceive('delete')->once()->andReturn(true);
-
-        $status = $activations->removeExpired();
+        $status = $this->activations->removeExpired();
 
         $this->assertTrue($status);
-    }
-
-    protected function getActivationMock()
-    {
-        $query = m::mock(Builder::class);
-
-        $model = m::mock(EloquentActivation::class);
-        $model->shouldReceive('newQuery')->andReturn($query);
-
-        $activations = m::mock('Cartalyst\Sentinel\Activations\IlluminateActivationRepository[createModel]', ['ActivationModelMock', 259200]);
-        $activations->shouldReceive('createModel')->andReturn($model);
-
-        return [$activations, $model, $query];
     }
 
     protected function getUserMock()
@@ -231,10 +231,5 @@ class IlluminateActivationRepositoryTest extends TestCase
         $user->shouldReceive('getUserId')->once()->andReturn(1);
 
         return $user;
-    }
-
-    protected function shouldReceiveExpires($query, $operator = '>')
-    {
-        $query->shouldReceive('where')->with('created_at', $operator, m::type(Carbon::class))->andReturn($query);
     }
 }

--- a/tests/Checkpoints/ActivationCheckpointTest.php
+++ b/tests/Checkpoints/ActivationCheckpointTest.php
@@ -68,6 +68,7 @@ class ActivationCheckpointTest extends TestCase
         $this->activations = null;
         $this->user        = null;
         $this->checkpoint  = null;
+
         m::close();
     }
 

--- a/tests/Checkpoints/ThrottleCheckpointTest.php
+++ b/tests/Checkpoints/ThrottleCheckpointTest.php
@@ -69,6 +69,7 @@ class ThrottleCheckpointTest extends TestCase
         $this->throttle   = null;
         $this->user       = null;
         $this->checkpoint = null;
+
         m::close();
     }
 

--- a/tests/Cookies/NullCookieTest.php
+++ b/tests/Cookies/NullCookieTest.php
@@ -25,27 +25,44 @@ use Cartalyst\Sentinel\Cookies\NullCookie;
 
 class NullCookieTest extends TestCase
 {
+    /**
+     * The cookie instance.
+     *
+     * @var \Cartalyst\Sentinel\Cookies\NullCookie
+     */
+    protected $cookie;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->cookie = new NullCookie();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        $this->cookie = null;
+    }
+
     /** @test */
     public function it_can_put_a_cookie()
     {
-        $cookie = new NullCookie();
-
-        $this->assertNull($cookie->put('cookie'));
+        $this->assertNull($this->cookie->put('cookie'));
     }
 
     /** @test */
     public function it_can_get_a_cookie()
     {
-        $cookie = new NullCookie();
-
-        $this->assertNull($cookie->get());
+        $this->assertNull($this->cookie->get());
     }
 
     /** @test */
     public function it_can_forget_a_cookie()
     {
-        $cookie = new NullCookie();
-
-        $this->assertNull($cookie->forget());
+        $this->assertNull($this->cookie->forget());
     }
 }

--- a/tests/Permissions/PermissibleTraitTest.php
+++ b/tests/Permissions/PermissibleTraitTest.php
@@ -43,6 +43,7 @@ class PermissibleTraitTest extends TestCase
     protected function tearDown(): void
     {
         $this->permissible = null;
+
         m::close();
     }
 

--- a/tests/Permissions/PermissibleTraitTest.php
+++ b/tests/Permissions/PermissibleTraitTest.php
@@ -32,119 +32,114 @@ class PermissibleTraitTest extends TestCase
     /**
      * {@inheritdoc}
      */
+    protected function setUp(): void
+    {
+        $this->permissible = new PermissibleStub();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown(): void
     {
+        $this->permissible = null;
         m::close();
     }
 
     /** @test */
     public function it_can_set_and_get_the_permissions_class()
     {
-        $permissible = new PermissibleStub();
+        $this->permissible::setPermissionsClass(StandardPermissions::class);
 
-        $permissible::setPermissionsClass(StandardPermissions::class);
-
-        $this->assertSame(StandardPermissions::class, $permissible::getPermissionsClass());
+        $this->assertSame(StandardPermissions::class, $this->permissible::getPermissionsClass());
     }
 
     /** @test */
     public function it_can_get_the_permissions_intance()
     {
-        $permissible = new PermissibleStub();
+        $this->permissible::setPermissionsClass(StandardPermissions::class);
 
-        $permissible::setPermissionsClass(StandardPermissions::class);
-
-        $this->assertInstanceOf(StandardPermissions::class, $permissible->getPermissionsInstance());
+        $this->assertInstanceOf(StandardPermissions::class, $this->permissible->getPermissionsInstance());
     }
 
     /** @test */
     public function it_can_add_permissions()
     {
-        $permissible = new PermissibleStub();
-
-        $permissible->addPermission('test');
-        $permissible->addPermission('test1');
+        $this->permissible->addPermission('test');
+        $this->permissible->addPermission('test1');
 
         $permissions = [
             'test'  => true,
             'test1' => true,
         ];
 
-        $this->assertSame($permissions, $permissible->getPermissions());
+        $this->assertSame($permissions, $this->permissible->getPermissions());
     }
 
     /** @test */
     public function it_can_update_permissions()
     {
-        $permissible = new PermissibleStub();
-
-        $permissible->addPermission('test');
-        $permissible->addPermission('test1');
-        $permissible->updatePermission('test1', false);
+        $this->permissible->addPermission('test');
+        $this->permissible->addPermission('test1');
+        $this->permissible->updatePermission('test1', false);
 
         $permissions = [
             'test'  => true,
             'test1' => false,
         ];
 
-        $this->assertSame($permissions, $permissible->getPermissions());
+        $this->assertSame($permissions, $this->permissible->getPermissions());
     }
 
     /** @test */
     public function it_can_create_or_update_permissions()
     {
-        $permissible = new PermissibleStub();
-
-        $permissible->addPermission('test1');
-        $permissible->updatePermission('test2', false);
+        $this->permissible->addPermission('test1');
+        $this->permissible->updatePermission('test2', false);
 
         $permissions = [
             'test1' => true,
         ];
 
-        $this->assertSame($permissions, $permissible->getPermissions());
+        $this->assertSame($permissions, $this->permissible->getPermissions());
 
-        $permissible = new PermissibleStub();
+        $this->permissible = new PermissibleStub();
 
-        $permissible->addPermission('test1');
-        $permissible->updatePermission('test2', false, true);
+        $this->permissible->addPermission('test1');
+        $this->permissible->updatePermission('test2', false, true);
 
         $permissions = [
             'test1' => true,
             'test2' => false,
         ];
 
-        $this->assertSame($permissions, $permissible->getPermissions());
+        $this->assertSame($permissions, $this->permissible->getPermissions());
     }
 
     /** @test */
     public function it_can_remove_permissions()
     {
-        $permissible = new PermissibleStub();
-
-        $permissible->addPermission('test');
-        $permissible->addPermission('test1');
-        $permissible->removePermission('test1');
+        $this->permissible->addPermission('test');
+        $this->permissible->addPermission('test1');
+        $this->permissible->removePermission('test1');
 
         $permissions = [
             'test' => true,
         ];
 
-        $this->assertSame($permissions, $permissible->getPermissions());
+        $this->assertSame($permissions, $this->permissible->getPermissions());
     }
 
     /** @test */
     public function it_can_use_the_setter_and_getter()
     {
-        $permissible = new PermissibleStub();
-
         $permissions = [
             'test' => true,
         ];
 
-        $permissible->setPermissions($permissions);
+        $this->permissible->setPermissions($permissions);
 
-        $this->assertSame($permissions, $permissible->getPermissions());
+        $this->assertSame($permissions, $this->permissible->getPermissions());
     }
 }
 

--- a/tests/Persistences/EloquentPersistenceTest.php
+++ b/tests/Persistences/EloquentPersistenceTest.php
@@ -33,33 +33,45 @@ use Cartalyst\Sentinel\Persistences\EloquentPersistence;
 class EloquentPersistenceTest extends TestCase
 {
     /**
+     * The Persistence instance.
+     *
+     * @var \Cartalyst\Sentinel\Persistences\EloquentPersistence
+     */
+    protected $persistence;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        $this->persistence = new EloquentPersistence();
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function tearDown(): void
     {
+        $this->persistence = null;
         m::close();
     }
 
     /** @test */
     public function it_can_get_the_user_relationship()
     {
-        $persistence = new EloquentPersistence();
+        $this->addMockConnection($this->persistence);
 
-        $this->addMockConnection($persistence);
-
-        $this->assertInstanceOf(BelongsTo::class, $persistence->user());
+        $this->assertInstanceOf(BelongsTo::class, $this->persistence->user());
     }
 
     /** @test */
     public function it_can_set_and_get_the_user_model_class_name()
     {
-        $persistence = new EloquentPersistence();
+        $this->assertSame(EloquentUser::class, $this->persistence->getUsersModel());
 
-        $this->assertSame(EloquentUser::class, $persistence->getUsersModel());
+        $this->persistence->setUsersModel('FooClass');
 
-        $persistence->setUsersModel('FooClass');
-
-        $this->assertSame('FooClass', $persistence->getUsersModel());
+        $this->assertSame('FooClass', $this->persistence->getUsersModel());
     }
 
     protected function addMockConnection($model)

--- a/tests/Persistences/EloquentPersistenceTest.php
+++ b/tests/Persistences/EloquentPersistenceTest.php
@@ -53,6 +53,7 @@ class EloquentPersistenceTest extends TestCase
     protected function tearDown(): void
     {
         $this->persistence = null;
+
         m::close();
     }
 

--- a/tests/Reminders/IlluminateReminderRepositoryTest.php
+++ b/tests/Reminders/IlluminateReminderRepositoryTest.php
@@ -83,6 +83,7 @@ class IlluminateReminderRepositoryTest extends TestCase
         $this->query     = null;
         $this->model     = null;
         $this->reminders = null;
+
         m::close();
     }
 

--- a/tests/Roles/EloquentRoleTest.php
+++ b/tests/Roles/EloquentRoleTest.php
@@ -36,8 +36,17 @@ class EloquentRoleTest extends TestCase
     /**
      * {@inheritdoc}
      */
+    protected function setUp(): void
+    {
+        $this->role = new EloquentRole();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown(): void
     {
+        $this->role = null;
         m::close();
     }
 
@@ -52,47 +61,39 @@ class EloquentRoleTest extends TestCase
     /** @test */
     public function it_can_get_the_permissions_using_the_accessor()
     {
-        $role = new EloquentRole();
-
-        $role->slug = 'foo';
+        $this->role->slug = 'foo';
 
         $permissions = ['foo' => true];
 
-        $role->permissions = $permissions;
+        $this->role->permissions = $permissions;
 
-        $this->assertSame($permissions, $role->permissions);
+        $this->assertSame($permissions, $this->role->permissions);
     }
 
     /** @test */
     public function it_can_get_the_users_for_the_role()
     {
-        $role = new EloquentRole();
+        $this->addMockConnection($this->role);
 
-        $this->addMockConnection($role);
-
-        $this->assertInstanceOf(Collection::class, $role->getUsers());
+        $this->assertInstanceOf(Collection::class, $this->role->getUsers());
     }
 
     /** @test */
     public function it_can_pass_methods_to_the_permissions_instance()
     {
-        $role = new EloquentRole();
-
-        $this->addMockConnection($role);
+        $this->addMockConnection($this->role);
 
         $permissions = [];
 
-        $this->assertFalse($role->hasAnyAccess($permissions));
+        $this->assertFalse($this->role->hasAnyAccess($permissions));
     }
 
     /** @test */
     public function it_can_get_the_users_relationship()
     {
-        $role = new EloquentRole();
+        $this->addMockConnection($this->role);
 
-        $this->addMockConnection($role);
-
-        $this->assertInstanceOf(BelongsToMany::class, $role->users());
+        $this->assertInstanceOf(BelongsToMany::class, $this->role->users());
     }
 
     /** @test */

--- a/tests/Roles/EloquentRoleTest.php
+++ b/tests/Roles/EloquentRoleTest.php
@@ -47,6 +47,7 @@ class EloquentRoleTest extends TestCase
     protected function tearDown(): void
     {
         $this->role = null;
+
         m::close();
     }
 

--- a/tests/Roles/IlluminateRoleRepositoryTest.php
+++ b/tests/Roles/IlluminateRoleRepositoryTest.php
@@ -30,6 +30,17 @@ class IlluminateRoleRepositoryTest extends TestCase
     /**
      * {@inheritdoc}
      */
+    protected function setUp(): void
+    {
+        $this->query = m::mock(Builder::class);
+        $this->model = m::mock(EloquentRole::class);
+        $this->roles = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository[createModel]');
+        $this->roles->shouldReceive('createModel')->andReturn($this->model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown(): void
     {
         m::close();
@@ -48,17 +59,11 @@ class IlluminateRoleRepositoryTest extends TestCase
     /** @test */
     public function it_can_find_a_role_using_its_id()
     {
-        $query = m::mock(Builder::class);
+        $this->model->shouldReceive('newQuery')->andReturn($this->query);
 
-        $model = m::mock(EloquentRole::class);
-        $model->shouldReceive('newQuery')->andReturn($query);
+        $this->query->shouldReceive('find')->with(1)->andReturn($this->model);
 
-        $roles = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository[createModel]');
-        $roles->shouldReceive('createModel')->andReturn($model);
-
-        $query->shouldReceive('find')->with(1)->andReturn($model);
-
-        $role = $roles->findById(1);
+        $role = $this->roles->findById(1);
 
         $this->assertInstanceOf(EloquentRole::class, $role);
     }
@@ -66,34 +71,22 @@ class IlluminateRoleRepositoryTest extends TestCase
     /** @test */
     public function it_can_find_a_role_using_its_slug()
     {
-        $query = m::mock(Builder::class);
+        $this->model->shouldReceive('newQuery')->andReturn($this->query);
 
-        $model = m::mock(EloquentRole::class);
-        $model->shouldReceive('newQuery')->andReturn($query);
+        $this->query->shouldReceive('where')->with('slug', 'foo')->andReturnSelf();
+        $this->query->shouldReceive('first')->once()->andReturn($this->model);
 
-        $roles = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository[createModel]');
-        $roles->shouldReceive('createModel')->andReturn($model);
-
-        $query->shouldReceive('where')->with('slug', 'foo')->andReturn($query);
-        $query->shouldReceive('first')->once()->andReturn($model);
-
-        $this->assertInstanceOf(EloquentRole::class, $roles->findBySlug('foo'));
+        $this->assertInstanceOf(EloquentRole::class, $this->roles->findBySlug('foo'));
     }
 
     /** @test */
     public function it_can_find_a_role_using_its_name()
     {
-        $query = m::mock(Builder::class);
+        $this->model->shouldReceive('newQuery')->andReturn($this->query);
 
-        $model = m::mock(EloquentRole::class);
-        $model->shouldReceive('newQuery')->andReturn($query);
+        $this->query->shouldReceive('where')->with('name', 'foo')->andReturnSelf();
+        $this->query->shouldReceive('first')->once()->andReturn($this->model);
 
-        $roles = m::mock('Cartalyst\Sentinel\Roles\IlluminateRoleRepository[createModel]');
-        $roles->shouldReceive('createModel')->andReturn($model);
-
-        $query->shouldReceive('where')->with('name', 'foo')->andReturn($query);
-        $query->shouldReceive('first')->once()->andReturn($model);
-
-        $this->assertInstanceOf(EloquentRole::class, $roles->findByName('foo'));
+        $this->assertInstanceOf(EloquentRole::class, $this->roles->findByName('foo'));
     }
 }

--- a/tests/Throttling/IlluminateThrottleRepositoryTest.php
+++ b/tests/Throttling/IlluminateThrottleRepositoryTest.php
@@ -35,6 +35,8 @@ class IlluminateThrottleRepositoryTest extends TestCase
 
     protected $model;
 
+    protected $models;
+
     protected $users;
 
     protected $throttle;
@@ -44,6 +46,8 @@ class IlluminateThrottleRepositoryTest extends TestCase
      */
     protected function setUp(): void
     {
+        $this->models = m::mock(Collection::class);
+
         $this->query = m::mock(Builder::class);
 
         $this->model = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
@@ -86,20 +90,19 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $first = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $first->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('first')->andReturn($first);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('first')->andReturn($first);
 
         $this->throttle->setGlobalInterval(10);
         $this->throttle->setGlobalThresholds(5);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'global')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'global')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(10, $this->throttle->globalDelay(), 3);
     }
@@ -110,20 +113,19 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $first = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $first->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('first')->andReturn($first);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('first')->andReturn($first);
 
         $this->throttle->setGlobalInterval(10);
         $this->throttle->setGlobalThresholds(200);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'global')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'global')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(0, $this->throttle->globalDelay(), 3);
     }
@@ -134,20 +136,19 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setGlobalInterval(10);
         $this->throttle->setGlobalThresholds([5 => 3, 10 => 10]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'global')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'global')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(3, $this->throttle->globalDelay(), 3);
     }
@@ -158,20 +159,19 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(11);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(11);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setGlobalInterval(10);
         $this->throttle->setGlobalThresholds([5 => 3, 10 => 10]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'global')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'global')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(10, $this->throttle->globalDelay(), 3);
     }
@@ -182,20 +182,19 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time() - 200));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(11);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(11);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setGlobalInterval(10);
         $this->throttle->setGlobalThresholds([5 => 33, 10 => 100]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'global')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'global')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(0, $this->throttle->globalDelay(), 3);
     }
@@ -206,21 +205,20 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $first = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $first->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('first')->andReturn($first);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('first')->andReturn($first);
 
         $this->throttle->setIpInterval(10);
         $this->throttle->setIpThresholds(5);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'ip')->andReturn($this->query);
-        $this->query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'ip')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(10, $this->throttle->ipDelay('127.0.0.1'), 3);
     }
@@ -231,21 +229,20 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setIpInterval(10);
         $this->throttle->setIpThresholds([5 => 3, 10 => 10]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'ip')->andReturn($this->query);
-        $this->query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'ip')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(3, $this->throttle->ipDelay('127.0.0.1'), 3);
     }
@@ -256,21 +253,20 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(11);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(11);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setIpInterval(10);
         $this->throttle->setIpThresholds([5 => 3, 10 => 10]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'ip')->andReturn($this->query);
-        $this->query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'ip')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('ip', '127.0.0.1')->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(10, $this->throttle->ipDelay('127.0.0.1'), 3);
     }
@@ -284,21 +280,20 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $first = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $first->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('first')->andReturn($first);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('first')->andReturn($first);
 
         $this->throttle->setUserInterval(10);
         $this->throttle->setUserThresholds(5);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'user')->andReturn($this->query);
-        $this->query->shouldReceive('where')->with('user_id', 1)->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'user')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('user_id', 1)->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(10, $this->throttle->userDelay($user), 3);
     }
@@ -312,21 +307,20 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(6);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(6);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setUserInterval(10);
         $this->throttle->setUserThresholds([5 => 3, 10 => 10]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'user')->andReturn($this->query);
-        $this->query->shouldReceive('where')->with('user_id', 1)->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'user')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('user_id', 1)->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(3, $this->throttle->userDelay($user), 3);
     }
@@ -340,21 +334,20 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $last = m::mock('Cartalyst\Sentinel\Throttling\EloquentThrottle');
         $last->shouldReceive('getAttribute')->andReturn(Carbon::createFromTimestamp(time()));
 
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(11);
-        $models->shouldReceive('last')->andReturn($last);
+        $this->models->shouldReceive('count')->andReturn(11);
+        $this->models->shouldReceive('last')->andReturn($last);
 
         $this->throttle->setUserInterval(10);
         $this->throttle->setUserThresholds([5 => 3, 10 => 10]);
 
-        $this->query->shouldReceive('get')->andReturn($models);
-        $this->query->shouldReceive('where')->with('type', 'user')->andReturn($this->query);
-        $this->query->shouldReceive('where')->with('user_id', 1)->andReturn($this->query);
+        $this->query->shouldReceive('get')->andReturn($this->models);
+        $this->query->shouldReceive('where')->with('type', 'user')->andReturnSelf();
+        $this->query->shouldReceive('where')->with('user_id', 1)->andReturnSelf();
         $this->query->shouldReceive('where')->with('created_at', '>', m::on(function ($interval) {
             $this->assertEqualsWithDelta(time() - 10, $interval->getTimestamp(), 3);
 
             return true;
-        }))->andReturn($this->query);
+        }))->andReturnSelf();
 
         $this->assertEqualsWithDelta(10, $this->throttle->userDelay($user), 3);
     }
@@ -362,11 +355,10 @@ class IlluminateThrottleRepositoryTest extends TestCase
     /** @test */
     public function testDelayHandlesNoThrottle()
     {
-        $models = m::mock(Collection::class);
-        $models->shouldReceive('count')->andReturn(0);
+        $this->models->shouldReceive('count')->andReturn(0);
 
         $this->query->shouldReceive('where')->andReturn($this->query);
-        $this->query->shouldReceive('get')->andReturn($models);
+        $this->query->shouldReceive('get')->andReturn($this->models);
 
         $this->assertSame($this->throttle->GlobalDelay(), 0);
     }
@@ -381,7 +373,7 @@ class IlluminateThrottleRepositoryTest extends TestCase
         $this->model->shouldReceive('save')->times(3);
         $this->model->shouldReceive('setAttribute');
 
-        $this->query->shouldReceive('where')->with('type', 'global')->andReturn($this->query);
+        $this->query->shouldReceive('where')->with('type', 'global')->andReturnSelf();
         $this->query->shouldReceive('where')->with('id', '=', '');
 
         $this->assertNull( // TODO: Add proper assertion later

--- a/tests/Users/EloquentUserTest.php
+++ b/tests/Users/EloquentUserTest.php
@@ -38,6 +38,14 @@ class EloquentUserTest extends TestCase
     /**
      * {@inheritdoc}
      */
+    protected function setUp(): void
+    {
+        $this->user = new EloquentUser();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown(): void
     {
         m::close();
@@ -46,33 +54,29 @@ class EloquentUserTest extends TestCase
     /** @test */
     public function it_can_get_the_user_permissions_from_the_accessor()
     {
-        $user       = new EloquentUser();
-        $user->slug = 'foo';
+        $this->user->slug = 'foo';
 
         $permissions = ['foo' => true];
 
-        $user->permissions = $permissions;
+        $this->user->permissions = $permissions;
 
-        $this->assertSame($permissions, $user->permissions);
+        $this->assertSame($permissions, $this->user->permissions);
     }
 
     /** @test */
     public function it_can_set_and_get_the_persistable_key()
     {
-        $user = new EloquentUser();
-        $user->setPersistableKey('foo_id');
+        $this->user->setPersistableKey('foo_id');
 
-        $this->assertSame('foo_id', $user->getPersistableKey());
+        $this->assertSame('foo_id', $this->user->getPersistableKey());
     }
 
     /** @test */
     public function it_can_set_and_get_the_persistable_relationship()
     {
-        $user = new EloquentUser();
+        $this->user->setPersistableRelationship('foo_persistences');
 
-        $user->setPersistableRelationship('foo_persistences');
-
-        $this->assertSame('foo_persistences', $user->getPersistableRelationship());
+        $this->assertSame('foo_persistences', $this->user->getPersistableRelationship());
     }
 
     /**
@@ -81,11 +85,9 @@ class EloquentUserTest extends TestCase
      */
     public function it_can_set_and_get_the_roles_model()
     {
-        $user = new EloquentUser();
+        $this->user->setRolesModel('RoleMock');
 
-        $user->setRolesModel('RoleMock');
-
-        $this->assertSame('RoleMock', $user->getRolesModel());
+        $this->assertSame('RoleMock', $this->user->getRolesModel());
     }
 
     /**
@@ -94,11 +96,9 @@ class EloquentUserTest extends TestCase
      */
     public function it_can_set_and_get_the_persistences_model()
     {
-        $user = new EloquentUser();
+        $this->user->setPersistencesModel('PersistenceMock');
 
-        $user->setPersistencesModel('PersistenceMock');
-
-        $this->assertSame('PersistenceMock', $user->getPersistencesModel());
+        $this->assertSame('PersistenceMock', $this->user->getPersistencesModel());
     }
 
     /**
@@ -107,11 +107,9 @@ class EloquentUserTest extends TestCase
      */
     public function it_can_set_and_get_the_activations_model()
     {
-        $user = new EloquentUser();
+        $this->user->setActivationsModel('ActivationMock');
 
-        $user->setActivationsModel('ActivationMock');
-
-        $this->assertSame('ActivationMock', $user->getActivationsModel());
+        $this->assertSame('ActivationMock', $this->user->getActivationsModel());
     }
 
     /**
@@ -120,11 +118,9 @@ class EloquentUserTest extends TestCase
      */
     public function it_can_set_and_get_the_reminders_model()
     {
-        $user = new EloquentUser();
+        $this->user->setRemindersModel('ReminderMock');
 
-        $user->setRemindersModel('ReminderMock');
-
-        $this->assertSame('ReminderMock', $user->getRemindersModel());
+        $this->assertSame('ReminderMock', $this->user->getRemindersModel());
     }
 
     /**
@@ -133,217 +129,190 @@ class EloquentUserTest extends TestCase
      */
     public function it_can_set_and_get_the_throttling_model()
     {
-        $user = new EloquentUser();
+        $this->user->setThrottlingModel('ThrottleMock');
 
-        $user->setThrottlingModel('ThrottleMock');
-
-        $this->assertSame('ThrottleMock', $user->getThrottlingModel());
+        $this->assertSame('ThrottleMock', $this->user->getThrottlingModel());
     }
 
     /** @test */
     public function it_can_get_the_user_id()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
+        $this->user->save();
 
-        $user->save();
-
-        $this->assertSame(1, $user->getUserId());
+        $this->assertSame(1, $this->user->getUserId());
     }
 
     /** @test */
     public function it_can_get_the_persistable_id()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
+        $this->user->save();
 
-        $user->save();
-
-        $this->assertSame('1', $user->getPersistableId());
+        $this->assertSame('1', $this->user->getPersistableId());
     }
 
     /** @test */
     public function it_can_get_the_user_login()
     {
-        $user        = new EloquentUser();
-        $user->email = 'foo@example.com';
+        $this->user->email = 'foo@example.com';
 
-        $this->addMockConnection($user);
+        $this->addMockConnection($this->user);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processInsertGetId')->andReturn(1);
 
-        $user->save();
+        $this->user->save();
 
-        $this->assertSame('foo@example.com', $user->getUserLogin());
+        $this->assertSame('foo@example.com', $this->user->getUserLogin());
     }
 
     /** @test */
     public function it_can_get_the_user_login_names()
     {
-        $user = new EloquentUser();
-
-        $this->assertSame(['email'], $user->getLoginNames());
+        $this->assertSame(['email'], $this->user->getLoginNames());
     }
 
     /** @test */
     public function it_can_get_the_user_login_name()
     {
-        $user = new EloquentUser();
-
-        $this->assertSame('email', $user->getUserLoginName());
+        $this->assertSame('email', $this->user->getUserLoginName());
     }
 
     /** @test */
     public function it_can_get_the_user_password()
     {
-        $user           = new EloquentUser();
-        $user->password = 'foobar';
+        $this->user->password = 'foobar';
 
-        $this->assertSame('foobar', $user->getUserPassword());
+        $this->assertSame('foobar', $this->user->getUserPassword());
     }
 
     /** @test */
     public function it_can_generate_a_persistence_code()
     {
-        $user = new EloquentUser();
-
-        $this->assertSame(32, strlen($user->generatePersistenceCode()));
+        $this->assertSame(32, strlen($this->user->generatePersistenceCode()));
     }
 
     /** @test */
     public function it_can_get_the_roles_relationship()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
-
-        $this->assertInstanceOf(BelongsToMany::class, $user->roles());
+        $this->assertInstanceOf(BelongsToMany::class, $this->user->roles());
     }
 
     /** @test */
     public function it_can_get_the_persistences_relationship()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
-
-        $this->assertInstanceOf(HasMany::class, $user->persistences());
+        $this->assertInstanceOf(HasMany::class, $this->user->persistences());
     }
 
     /** @test */
     public function it_can_get_the_reminders_relationship()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
-
-        $this->assertInstanceOf(HasMany::class, $user->reminders());
+        $this->assertInstanceOf(HasMany::class, $this->user->reminders());
     }
 
     /** @test */
     public function it_can_get_the_activations_relationship()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
-
-        $this->assertInstanceOf(HasMany::class, $user->activations());
+        $this->assertInstanceOf(HasMany::class, $this->user->activations());
     }
 
     /** @test */
     public function it_can_get_the_throttles_relationship()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
 
-        $this->addMockConnection($user);
-
-        $this->assertInstanceOf(HasMany::class, $user->throttle());
+        $this->assertInstanceOf(HasMany::class, $this->user->throttle());
     }
 
     /** @test */
     public function it_can_check_if_user_is_in_role_using_role_slugs()
     {
-        $user     = new EloquentUser();
-        $user->id = 0;
+        $this->user->id = 0;
 
-        $this->addMockConnection($user);
+        $this->addMockConnection($this->user);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
             ['id' => 1, 'slug' => 'role1'],
             ['id' => 2, 'slug' => 'role2'],
             ['id' => 3, 'slug' => 'role3'],
         ]);
 
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
-        $user->getConnection()->shouldReceive('select');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
+        $this->user->getConnection()->shouldReceive('select');
 
-        $this->assertTrue($user->inRole('role1'));
-        $this->assertTrue($user->inRole('role2'));
-        $this->assertTrue($user->inRole('role3'));
-        $this->assertFalse($user->inRole('role4'));
+        $this->assertTrue($this->user->inRole('role1'));
+        $this->assertTrue($this->user->inRole('role2'));
+        $this->assertTrue($this->user->inRole('role3'));
+        $this->assertFalse($this->user->inRole('role4'));
     }
 
     /** @test */
     public function it_can_check_if_user_is_in_role_using_an_array_of_role_slugs()
     {
-        $user     = new EloquentUser();
-        $user->id = 0;
+        $this->user->id = 0;
 
-        $this->addMockConnection($user);
+        $this->addMockConnection($this->user);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
             ['id' => 1, 'slug' => 'role1'],
             ['id' => 2, 'slug' => 'role2'],
             ['id' => 3, 'slug' => 'role3'],
         ]);
 
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
-        $user->getConnection()->shouldReceive('select');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
+        $this->user->getConnection()->shouldReceive('select');
 
-        $this->assertTrue($user->inAnyRole(['role1', 'role2']));
-        $this->assertTrue($user->inAnyRole(['role3', 'role4']));
-        $this->assertFalse($user->inAnyRole(['role5', 'role6']));
+        $this->assertTrue($this->user->inAnyRole(['role1', 'role2']));
+        $this->assertTrue($this->user->inAnyRole(['role3', 'role4']));
+        $this->assertFalse($this->user->inAnyRole(['role5', 'role6']));
     }
 
     /** @test */
     public function it_can_check_if_user_is_in_role_using_role_instances()
     {
-        $user     = new EloquentUser();
-        $user->id = 0;
+        $this->user->id = 0;
 
-        $this->addMockConnection($user);
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
+        $this->addMockConnection($this->user);
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
             ['id' => 1, 'slug' => 'role1'],
             ['id' => 2, 'slug' => 'role2'],
             ['id' => 3, 'slug' => 'role3'],
         ]);
 
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
-        $user->getConnection()->shouldReceive('select');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
+        $this->user->getConnection()->shouldReceive('select');
 
         $role1 = m::mock(RoleInterface::class);
         $role2 = m::mock(RoleInterface::class);
@@ -355,30 +324,29 @@ class EloquentUserTest extends TestCase
         $role3->shouldReceive('getRoleId')->once()->andReturn(3);
         $role4->shouldReceive('getRoleId')->once()->andReturn(4);
 
-        $this->assertTrue($user->inRole($role1));
-        $this->assertTrue($user->inRole($role2));
-        $this->assertTrue($user->inRole($role3));
-        $this->assertFalse($user->inRole($role4));
+        $this->assertTrue($this->user->inRole($role1));
+        $this->assertTrue($this->user->inRole($role2));
+        $this->assertTrue($this->user->inRole($role3));
+        $this->assertFalse($this->user->inRole($role4));
     }
 
     /** @test */
     public function it_can_check_if_user_is_in_role_using_an_array_of_role_instances()
     {
-        $user     = new EloquentUser();
-        $user->id = 0;
+        $this->user->id = 0;
 
-        $this->addMockConnection($user);
+        $this->addMockConnection($this->user);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileInsertGetId');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([
             ['id' => 1, 'slug' => 'foobar'],
             ['id' => 2, 'slug' => 'foo'],
             ['id' => 3, 'slug' => 'bar'],
         ]);
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
-        $user->getConnection()->shouldReceive('select');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
+        $this->user->getConnection()->shouldReceive('select');
 
         $foobar = m::mock(RoleInterface::class);
         $foo    = m::mock(RoleInterface::class);
@@ -395,41 +363,38 @@ class EloquentUserTest extends TestCase
         $def->shouldReceive('getRoleId')->once()->andReturn(5);
         $ghi->shouldReceive('getRoleId')->once()->andReturn(6);
 
-        $this->assertFalse($user->inAnyRole([$abc, $def]));
-        $this->assertTrue($user->inAnyRole([$ghi, $foobar]));
-        $this->assertTrue($user->inAnyRole([$foo, $bar]));
+        $this->assertFalse($this->user->inAnyRole([$abc, $def]));
+        $this->assertTrue($this->user->inAnyRole([$ghi, $foobar]));
+        $this->assertTrue($this->user->inAnyRole([$foo, $bar]));
     }
 
     /** @test */
     public function it_can_get_the_roles_of_a_user()
     {
-        $user     = new EloquentUser();
-        $user->id = 0;
+        $this->user->id = 0;
 
-        $this->addMockConnection($user);
+        $this->addMockConnection($this->user);
 
-        $user->getConnection()->shouldReceive('getName');
-        $user->getConnection()->shouldReceive('select');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
-        $user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([]);
+        $this->user->getConnection()->shouldReceive('getName');
+        $this->user->getConnection()->shouldReceive('select');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileSelect');
+        $this->user->getConnection()->getPostProcessor()->shouldReceive('processSelect')->andReturn([]);
 
-        $this->assertInstanceOf(Collection::class, $user->getRoles());
+        $this->assertInstanceOf(Collection::class, $this->user->getRoles());
     }
 
     /** @test */
     public function it_can_pass_methods_to_parent()
     {
-        $user = new EloquentUser();
+        $this->addMockConnection($this->user);
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('wrap');
+        $this->user->getConnection()->shouldReceive('raw');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('compileUpdate');
+        $this->user->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForUpdate')->andReturn([]);
+        $this->user->getConnection()->shouldReceive('update')->andReturn(true);
 
-        $this->addMockConnection($user);
-        $user->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('wrap');
-        $user->getConnection()->shouldReceive('raw');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('compileUpdate');
-        $user->getConnection()->getQueryGrammar()->shouldReceive('prepareBindingsForUpdate')->andReturn([]);
-        $user->getConnection()->shouldReceive('update')->andReturn(true);
-
-        $this->assertTrue($user->increment('test'));
+        $this->assertTrue($this->user->increment('test'));
     }
 
     /** @test */
@@ -438,12 +403,11 @@ class EloquentUserTest extends TestCase
         $mockRole              = m::mock(EloquentRole::class);
         $mockRole->permissions = [];
 
-        $user              = new EloquentUser();
-        $user->permissions = ['foo' => true, 'bar' => false];
-        $user->roles       = [$mockRole];
+        $this->user->permissions = ['foo' => true, 'bar' => false];
+        $this->user->roles       = [$mockRole];
 
-        $this->assertTrue($user->hasAccess('foo'));
-        $this->assertFalse($user->hasAccess('bar'));
+        $this->assertTrue($this->user->hasAccess('foo'));
+        $this->assertFalse($this->user->hasAccess('bar'));
     }
 
     /** @test */

--- a/tests/Users/IlluminateUserRepositoryTest.php
+++ b/tests/Users/IlluminateUserRepositoryTest.php
@@ -57,6 +57,7 @@ class IlluminateUserRepositoryTest extends TestCase
         $this->query  = null;
         $this->model  = null;
         $this->users  = null;
+
         m::close();
     }
 

--- a/tests/Users/IlluminateUserRepositoryTest.php
+++ b/tests/Users/IlluminateUserRepositoryTest.php
@@ -33,18 +33,38 @@ class IlluminateUserRepositoryTest extends TestCase
     /**
      * {@inheritdoc}
      */
+    protected function setUp(): void
+    {
+        $this->hasher = m::mock(NativeHasher::class);
+
+        $this->query = m::mock(Builder::class);
+
+        $this->model = m::mock('Cartalyst\Sentinel\Users\EloquentUser');
+        $this->model->shouldReceive('newQuery')->andReturn($this->query);
+
+        $this->users = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository[createModel]', [
+            $this->hasher,
+        ]);
+        $this->users->shouldReceive('createModel')->andReturn($this->model);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function tearDown(): void
     {
+        $this->hasher = null;
+        $this->query  = null;
+        $this->model  = null;
+        $this->users  = null;
         m::close();
     }
 
     /** @test */
     public function it_can_be_instantiated()
     {
-        $hasher = m::mock(NativeHasher::class);
-
         $users = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository[createModel,findById]', [
-            $hasher, null, 'UserMock',
+            $this->hasher, null, 'UserMock',
         ]);
 
         $this->assertSame('UserMock', $users->getModel());
@@ -53,11 +73,9 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_find_a_user_by_its_id()
     {
-        [$users, $hasher, $model, $query] = $this->getUsersMock();
+        $this->query->shouldReceive('find')->with(1)->once()->andReturn($this->model);
 
-        $query->shouldReceive('find')->with(1)->once()->andReturn($model);
-
-        $user = $users->findById(1);
+        $user = $this->users->findById(1);
 
         $this->assertInstanceOf(EloquentUser::class, $user);
     }
@@ -65,14 +83,12 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_find_a_user_by_its_credentials_1()
     {
-        [$users, $hasher, $model, $query] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->query->shouldReceive('where')->with('email', 'foo@example.com')->once()->andReturn($this->model);
+        $this->query->shouldReceive('first')->once()->andReturn($this->model);
 
-        $query->shouldReceive('where')->with('email', 'foo@example.com')->once()->andReturn($model);
-        $query->shouldReceive('first')->once()->andReturn($model);
-
-        $user = $users->findByCredentials([
+        $user = $this->users->findByCredentials([
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ]);
@@ -83,19 +99,17 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_find_a_user_by_its_credentials_2()
     {
-        [$users, $hasher, $model, $query] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email', 'username']);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email', 'username']);
+        $this->query->shouldReceive('whereNested')->with(m::on(function ($argument) {
+            $this->query->shouldReceive('where')->with('email', 'foo@example.com');
+            $this->query->shouldReceive('orWhere')->with('username', 'foo@example.com');
 
-        $query->shouldReceive('whereNested')->with(m::on(function ($argument) use ($query) {
-            $query->shouldReceive('where')->with('email', 'foo@example.com');
-            $query->shouldReceive('orWhere')->with('username', 'foo@example.com');
+            return null === $argument($this->query);
+        }))->andReturn($this->model);
+        $this->query->shouldReceive('first')->once()->andReturn($this->model);
 
-            return null === $argument($query);
-        }))->andReturn($model);
-        $query->shouldReceive('first')->once()->andReturn($model);
-
-        $user = $users->findByCredentials([
+        $user = $this->users->findByCredentials([
             'login'    => 'foo@example.com',
             'password' => 'secret',
         ]);
@@ -106,18 +120,16 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_find_a_user_by_its_credentials_3()
     {
-        [$users, $hasher, $model, $query] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->query->shouldReceive('whereNested')->with(m::on(function ($argument) {
+            $this->query->shouldReceive('where')->with('email', 'foo@example.com');
 
-        $query->shouldReceive('whereNested')->with(m::on(function ($argument) use ($query) {
-            $query->shouldReceive('where')->with('email', 'foo@example.com');
+            return null === $argument($this->query);
+        }))->andReturn($this->model);
+        $this->query->shouldReceive('first')->once()->andReturn($this->model);
 
-            return null === $argument($query);
-        }))->andReturn($model);
-        $query->shouldReceive('first')->once()->andReturn($model);
-
-        $user = $users->findByCredentials([
+        $user = $this->users->findByCredentials([
             'login' => 'foo@example.com',
         ]);
 
@@ -127,11 +139,9 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_cannot_find_a_user_by_invalid_credentials_1()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-
-        $user = $users->findByCredentials([
+        $user = $this->users->findByCredentials([
             'password' => 'secret',
         ]);
 
@@ -141,11 +151,9 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_cannot_find_a_user_by_invalid_credentials_2()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-
-        $user = $users->findByCredentials([
+        $user = $this->users->findByCredentials([
             'username' => 'foo',
         ]);
 
@@ -155,26 +163,22 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_cannot_find_a_user_by_invalid_credentials_3()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-
-        $this->assertNull($users->findByCredentials([]));
+        $this->assertNull($this->users->findByCredentials([]));
     }
 
     /** @test */
     public function it_can_find_a_user_by_its_persistence_code()
     {
-        [$users, $hasher, $model, $query] = $this->getUsersMock();
+        $this->query->shouldReceive('whereHas')->with('persistences', m::on(function ($argument) {
+            $this->query->shouldReceive('where')->with('code', 'foobar');
 
-        $query->shouldReceive('whereHas')->with('persistences', m::on(function ($argument) use ($query) {
-            $query->shouldReceive('where')->with('code', 'foobar');
+            return null === $argument($this->query);
+        }))->andReturn($this->model);
+        $this->model->shouldReceive('first')->once()->andReturn($this->model);
 
-            return null === $argument($query);
-        }))->andReturn($model);
-        $model->shouldReceive('first')->once()->andReturn($model);
-
-        $user = $users->findByPersistenceCode('foobar');
+        $user = $this->users->findByPersistenceCode('foobar');
 
         $this->assertInstanceOf(EloquentUser::class, $user);
     }
@@ -182,34 +186,28 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_record_the_login()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('setAttribute');
+        $this->model->shouldReceive('save')->once()->andReturn(true);
 
-        $model->shouldReceive('setAttribute');
-        $model->shouldReceive('save')->once()->andReturn(true);
-
-        $this->assertTrue($users->recordLogin($model));
+        $this->assertTrue($this->users->recordLogin($this->model));
     }
 
     /** @test */
     public function it_can_record_the_logout()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('save')->once()->andReturn(true);
 
-        $model->shouldReceive('save')->once()->andReturn(true);
-
-        $this->assertTrue($users->recordLogout($model));
+        $this->assertTrue($this->users->recordLogout($this->model));
     }
 
     /** @test */
     public function it_can_validate_the_credentials()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getAttribute')->andReturn('secret');
 
-        $model->shouldReceive('getAttribute')->andReturn('secret');
+        $this->hasher->shouldReceive('check')->with('secret', 'secret')->once()->andReturn(true);
 
-        $hasher->shouldReceive('check')->with('secret', 'secret')->once()->andReturn(true);
-
-        $valid = $users->validateCredentials($model, [
+        $valid = $this->users->validateCredentials($this->model, [
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ]);
@@ -220,18 +218,14 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_check_if_the_user_is_valid_for_being_created()
     {
-        $user = new EloquentUser();
-
-        [$users, $hasher, $model] = $this->getUsersMock();
-
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
         $credentials = [
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ];
 
-        $valid = $users->validForCreation($credentials);
+        $valid = $this->users->validForCreation($credentials);
 
         $this->assertTrue($valid);
     }
@@ -241,18 +235,16 @@ class IlluminateUserRepositoryTest extends TestCase
     {
         $user = $this->fakeUser();
 
-        [$users, $hasher, $model] = $this->getUsersMock();
-
         $user->shouldReceive('getUserId')->once()->andReturn(1);
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
         $credentials = [
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ];
 
-        $valid = $users->validForUpdate($user, $credentials);
+        $valid = $this->users->validForUpdate($user, $credentials);
 
         $this->assertTrue($valid);
     }
@@ -260,15 +252,13 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_create_a_user_using_login()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('fill');
+        $this->model->shouldReceive('save')->once();
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-        $model->shouldReceive('fill');
-        $model->shouldReceive('save')->once();
+        $this->hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
 
-        $hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
-
-        $user = $users->create([
+        $user = $this->users->create([
             'login'    => 'foo@example.com',
             'password' => 'secret',
         ]);
@@ -279,15 +269,13 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_create_a_user()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('fill');
+        $this->model->shouldReceive('save')->once();
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-        $model->shouldReceive('fill');
-        $model->shouldReceive('save')->once();
+        $this->hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
 
-        $hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
-
-        $user = $users->create([
+        $user = $this->users->create([
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ]);
@@ -298,15 +286,13 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_create_a_user_with_valid_callback()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('fill');
+        $this->model->shouldReceive('save')->once();
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-        $model->shouldReceive('fill');
-        $model->shouldReceive('save')->once();
+        $this->hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
 
-        $hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
-
-        $user = $users->create([
+        $user = $this->users->create([
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ], function ($user) {
@@ -319,14 +305,12 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_will_not_create_a_user_with_an_invalid_callback()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('fill');
 
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
-        $model->shouldReceive('fill');
+        $this->hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
 
-        $hasher->shouldReceive('hash')->once()->with('secret')->andReturn(password_hash('secret', PASSWORD_DEFAULT));
-
-        $user = $users->create([
+        $user = $this->users->create([
             'email'    => 'foo@example.com',
             'password' => 'secret',
         ], function ($user) {
@@ -339,14 +323,12 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_update_a_user_by_instance()
     {
-        [$users, $hasher, $model] = $this->getUsersMock();
-
         $user = $this->fakeUser();
         $user->shouldReceive('getLoginNames')->andReturn(['email']);
         $user->shouldReceive('fill');
         $user->shouldReceive('save')->once();
 
-        $user = $users->update($user, [
+        $user = $this->users->update($user, [
             'email' => 'foo1@example.com',
         ]);
 
@@ -356,16 +338,14 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_update_a_user_by_id()
     {
-        [$users, $hasher, $model, $query] = $this->getUsersMock();
-
         $user = $this->fakeUser();
         $user->shouldReceive('getLoginNames')->andReturn(['email']);
         $user->shouldReceive('fill');
         $user->shouldReceive('save')->once();
 
-        $query->shouldReceive('find')->once()->with(1)->andReturn($user);
+        $this->query->shouldReceive('find')->once()->with(1)->andReturn($user);
 
-        $user = $users->update(1, [
+        $user = $this->users->update(1, [
             'email' => 'foo1@example.com',
         ]);
 
@@ -375,13 +355,11 @@ class IlluminateUserRepositoryTest extends TestCase
     /** @test */
     public function it_can_set_and_get_the_hashing_strategy()
     {
-        [$users] = $this->getUsersMock();
+        $this->assertInstanceOf(NativeHasher::class, $this->users->getHasher());
 
-        $this->assertInstanceOf(NativeHasher::class, $users->getHasher());
+        $this->users->setHasher(m::mock(HasherInterface::class));
 
-        $users->setHasher(m::mock(HasherInterface::class));
-
-        $this->assertInstanceOf(HasherInterface::class, $users->getHasher());
+        $this->assertInstanceOf(HasherInterface::class, $this->users->getHasher());
     }
 
     /** @test */
@@ -390,15 +368,13 @@ class IlluminateUserRepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No [login] credential was passed.');
 
-        [$users, $hasher, $model] = $this->getUsersMock();
-
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
         $credentials = [
             'password' => 'secret',
         ];
 
-        $users->validForCreation($credentials);
+        $this->users->validForCreation($credentials);
     }
 
     /** @test */
@@ -407,15 +383,13 @@ class IlluminateUserRepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You have not passed a [password].');
 
-        [$users, $hasher, $model] = $this->getUsersMock();
-
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
         $credentials = [
             'email' => 'foo@example.com',
         ];
 
-        $users->validForCreation($credentials);
+        $this->users->validForCreation($credentials);
     }
 
     /** @test */
@@ -424,37 +398,18 @@ class IlluminateUserRepositoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You have not passed a [password].');
 
-        [$users, $hasher, $model] = $this->getUsersMock();
-
-        $model->shouldReceive('getLoginNames')->andReturn(['email']);
+        $this->model->shouldReceive('getLoginNames')->andReturn(['email']);
 
         $credentials = [
             'email'    => 'foo@example.com',
             'password' => null,
         ];
 
-        $users->validForCreation($credentials);
+        $this->users->validForCreation($credentials);
     }
 
     protected function fakeUser()
     {
         return m::mock('Cartalyst\Sentinel\Users\EloquentUser');
-    }
-
-    protected function getUsersMock()
-    {
-        $hasher = m::mock(NativeHasher::class);
-
-        $query = m::mock(Builder::class);
-
-        $model = m::mock('Cartalyst\Sentinel\Users\EloquentUser');
-        $model->shouldReceive('newQuery')->andReturn($query);
-
-        $users = m::mock('Cartalyst\Sentinel\Users\IlluminateUserRepository[createModel]', [
-            $hasher,
-        ]);
-        $users->shouldReceive('createModel')->andReturn($model);
-
-        return [$users, $hasher, $model, $query];
     }
 }


### PR DESCRIPTION
moved most mock and object creations to ```TestCase::setUp``` to hopefully improve readabliity for some tests.
```shouldReceiveExpires``` methods used for building query mock have been removed for better consistency. for example see ```IlluminateActivationRepository```.
