### PR TITLE
Remove duplicate null check

### DIFF
--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -309,7 +309,7 @@ class Sentinel
 
             $valid = $user !== null ? $this->users->validateCredentials($user, $credentials) : false;
 
-            if ($user === null || ! $valid) {
+            if (! $valid) {
                 $this->cycleCheckpoints('fail', $user, false);
 
                 return false;

--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -164,9 +164,9 @@ class Sentinel
      *
      * @return bool|\Cartalyst\Sentinel\Users\UserInterface
      */
-    public function register(array $credentials, $callback = null)
+    public function register(array $credentials, $callback = false)
     {
-        if ($callback !== null && ! $callback instanceof Closure && ! is_bool($callback)) {
+        if (! $callback instanceof Closure && ! is_bool($callback)) {
             throw new InvalidArgumentException('You must provide a closure or a boolean.');
         }
 


### PR DESCRIPTION
this null check isn't needed as it's already checked in the line above. 

edit: the default callback type for ```Sentinel::register``` should be a bool.