### PR TITLE
Allow EloquentUser to ignore empty secondary permissons.

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -478,7 +478,9 @@ class EloquentUser extends Model implements PermissibleInterface, PersistableInt
         $rolePermissions = [];
 
         foreach ($this->roles as $role) {
-            $rolePermissions[] = $role->permissions;
+            if (! empty($role->permissions)) {
+                $rolePermissions[] = $role->permissions;
+            }
         }
 
         return new static::$permissionsClass($userPermissions, $rolePermissions);

--- a/tests/Users/EloquentUserTest.php
+++ b/tests/Users/EloquentUserTest.php
@@ -411,6 +411,19 @@ class EloquentUserTest extends TestCase
     }
 
     /** @test */
+    public function it_ignores_empty_secondary_permissions_when_checking_access()
+    {
+        $mockRole              = m::mock(EloquentRole::class);
+        $mockRole->permissions = null;
+
+        $this->user->permissions = ['foo' => true, 'bar' => false];
+        $this->user->roles       = [$mockRole];
+
+        $this->assertTrue($this->user->hasAccess('foo'));
+        $this->assertFalse($this->user->hasAccess('bar'));
+    }
+
+    /** @test */
     public function it_can_delete_a_user()
     {
         $user         = m::mock('Cartalyst\Sentinel\Users\EloquentUser[roles,persistences,activations,reminders,throttle]');


### PR DESCRIPTION
Hello,

Thank you for this excellent package - I have been using it for years and I am very grateful for the work you have done. 

This PR addresses a potential bug I have found, though it is possible that I am operating with incomplete knowledge. 

It is my understanding that the migration provided for Laravel applications allows the `permissions` field on users and roles to be nullable.   The `preparePermissions` method in the `PermissionsTrait` class requires that the permissions be provided as an array.  When constructing user permissions for a user that belongs to a role with no permissions, the `createPermissions` method on the `EloquentUser` class will pass on a null value to the `preparePermissions` method, throwing an error. 

This PR updates that `createPermissions` method to ignore roles with empty permissions. 

Thanks again!