### PR TITLE
fix: Add missing argument type declarations

### DIFF
--- a/src/Permissions/PermissibleTrait.php
+++ b/src/Permissions/PermissibleTrait.php
@@ -134,7 +134,7 @@ trait PermissibleTrait
     /**
      * {@inheritdoc}
      */
-    public function removePermission($permission): PermissibleInterface
+    public function removePermission(string $permission): PermissibleInterface
     {
         if (array_key_exists($permission, $this->permissions)) {
             $permissions = $this->permissions;

--- a/src/Persistences/IlluminatePersistenceRepository.php
+++ b/src/Persistences/IlluminatePersistenceRepository.php
@@ -174,7 +174,7 @@ class IlluminatePersistenceRepository implements PersistenceRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function flush(PersistableInterface $persistable, $forget = true): void
+    public function flush(PersistableInterface $persistable, bool $forget = true): void
     {
         if ($forget) {
             $this->forget();

--- a/src/Roles/EloquentRole.php
+++ b/src/Roles/EloquentRole.php
@@ -123,7 +123,7 @@ class EloquentRole extends Model implements PermissibleInterface, RoleInterface
     /**
      * {@inheritdoc}
      */
-    public static function setUsersModel($usersModel): void
+    public static function setUsersModel(string $usersModel): void
     {
         static::$usersModel = $usersModel;
     }


### PR DESCRIPTION
Exceptions are thrown absent these declarations (i.e., this is not merely a style/syntax change).