### PR TITLE
Add inAnyRole to the list of static methods

### DIFF
--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -925,7 +925,7 @@ class Sentinel
             return call_user_func_array([$roles, $method], $parameters);
         }
 
-        $methods = ['getRoles', 'inRole', 'hasAccess', 'hasAnyAccess'];
+        $methods = ['getRoles', 'inRole', 'inAnyRole', 'hasAccess', 'hasAnyAccess'];
 
         $className = get_class($this);
 


### PR DESCRIPTION
Calling Sentinel::inAnyRole() wouldn't work while Sentinel::inRole() was working in the same context.