### PR TITLE
Dropped return type for getUserId in order to support UUIDs

### DIFF
--- a/src/Users/EloquentUser.php
+++ b/src/Users/EloquentUser.php
@@ -246,7 +246,7 @@ class EloquentUser extends Model implements PermissibleInterface, PersistableInt
     /**
      * {@inheritdoc}
      */
-    public function getUserId(): int
+    public function getUserId()
     {
         return $this->getKey();
     }

--- a/src/Users/UserInterface.php
+++ b/src/Users/UserInterface.php
@@ -25,9 +25,9 @@ interface UserInterface
     /**
      * Returns the user primary key.
      *
-     * @return int
+     * @return int|string
      */
-    public function getUserId(): int;
+    public function getUserId();
 
     /**
      * Returns the user login.


### PR DESCRIPTION
I came across this issue because I setup a custom model to serve as user model and by using UUIDs instead of numeric IDs. 

The user model extends `Cartalyst\Sentinel\Users\EloquentUser`. The implemented interface, `Cartalyst\Sentinel\Users\UserInterface`, defines a return type. 

This method can't be overridden by extending this interface. Using my custom model and creating an interface of my own (obviously) results in Sentinel becoming unusable because it expects the user model to be of type `Cartalyst\Sentinel\Users\UserInterface`.