### PR TITLE
Added option to set up db tables using phinx

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -9,3 +9,7 @@ If yours does not or for whatever reason you need to install manually:
 Run or source mysql.sql for MySQL 5.5.x and below & forks of similar code base
 
 Run or source mysql-5.6+.sql for MySQL 5.6.x and up & forks of similar code base 
+
+* You can also use phinx to setup these table. 
+    * You would have to run `composer require  robmorgan/phinx "^0.12.0" --dev` and then setup phinx to run the migration located in **./schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php** . See [here](https://book.cakephp.org/phinx/0/en/) for phinx documentation.
+    * Setting up the db tables this way would allow you to be able to use other db engines like sqlite, PostgreSql and Sql Server with sentinel

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,6 +10,6 @@ Run or source mysql.sql for MySQL 5.5.x and below & forks of similar code base
 
 Run or source mysql-5.6+.sql for MySQL 5.6.x and up & forks of similar code base 
 
-* You can also use phinx to setup these table. 
-    * You would have to run `composer require  robmorgan/phinx "^0.12.0" --dev` and then setup phinx to run the migration located in **./schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php** . See [here](https://book.cakephp.org/phinx/0/en/) for phinx documentation.
-    * Setting up the db tables this way would allow you to be able to use other db engines like sqlite, PostgreSql and Sql Server with sentinel
+You can also use phinx to setup these tables. 
+* You would have to run `composer require  robmorgan/phinx "^0.12.0" --dev` and then setup phinx to run the migrations located in **./schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php** . See [here](https://book.cakephp.org/phinx/0/en/) for phinx documentation.
+* Setting up the db tables this way would allow you to be able to use other db engines like sqlite, PostgreSql and Sql Server with sentinel

--- a/schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php
+++ b/schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php
@@ -23,9 +23,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
               PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
         */
-        if( !$this->hasTable('cartalyst_activations') ) {
+        if( !$this->hasTable('activations') ) {
 
-            $table = $this->table('cartalyst_activations');
+            $table = $this->table('activations');
             $table//->addColumn('id', 'integer', ['signed' => false, 'identity' => true]) // automatically generated
                   ->addColumn('user_id', 'integer', ['signed' => false, 'null' => false])
                   ->addColumn('code', 'string', ['limit' => 255, 'null' => false]);
@@ -44,7 +44,7 @@ final class AddCartalystTablesToDb extends AbstractMigration
                   ->addColumn('updated_at', 'timestamp',    ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
                   ->create();
             
-        } // if( !$this->hasTable('cartalyst_activations') )
+        } // if( !$this->hasTable('activations') )
         
         /**
         # Dump of table persistences
@@ -60,9 +60,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
                 UNIQUE KEY `persistences_code_unique` (`code`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
         */
-        if( !$this->hasTable('cartalyst_persistences') ) {
+        if( !$this->hasTable('persistences') ) {
             
-            $table = $this->table('cartalyst_persistences');
+            $table = $this->table('persistences');
             $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
                   ->addColumn('user_id', 'integer', ['signed'=>false, 'null'=>false])
                   ->addColumn('code', 'string', ['limit'=>255, 'null'=>false])
@@ -87,9 +87,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
                 PRIMARY KEY (`id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
         */
-        if( !$this->hasTable('cartalyst_reminders') ) {
+        if( !$this->hasTable('reminders') ) {
             
-            $table = $this->table('cartalyst_reminders');
+            $table = $this->table('reminders');
             $table//->addColumn('id', 'integer', ['signed' => false, 'identity' => true]) // automatically generated
                   ->addColumn('user_id', 'integer', ['signed' => false, 'null' => false])
                   ->addColumn('code', 'string', ['limit' => 255, 'null' => false]);
@@ -124,9 +124,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
                 UNIQUE KEY `roles_slug_unique` (`slug`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci; 
         */
-        if( !$this->hasTable('cartalyst_roles') ) {
+        if( !$this->hasTable('roles') ) {
             
-            $table = $this->table('cartalyst_roles');
+            $table = $this->table('roles');
             $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
                   ->addColumn('slug', 'string', ['limit'=>255, 'null'=>false])
                   ->addColumn('name', 'string', ['limit'=>255, 'null'=>false])
@@ -149,9 +149,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
                 PRIMARY KEY (`user_id`,`role_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
         */
-        if( !$this->hasTable('cartalyst_role_users') ) {
+        if( !$this->hasTable('role_users') ) {
             
-            $table = $this->table('cartalyst_role_users');
+            $table = $this->table('role_users');
             $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
                   ->addColumn('user_id', 'integer', ['signed'=>false, 'null'=>false])
                   ->addColumn('role_id', 'integer', ['signed'=>false, 'null'=>false])
@@ -175,9 +175,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
                 KEY `throttle_user_id_index` (`user_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
         */
-        if( !$this->hasTable('cartalyst_throttle') ) {
+        if( !$this->hasTable('throttle') ) {
             
-            $table = $this->table('cartalyst_throttle');
+            $table = $this->table('throttle');
             $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
                   ->addColumn('user_id', 'integer', ['signed'=>false, 'null'=>false])
                   ->addColumn('type', 'string', ['limit'=>255, 'null'=>false])
@@ -206,9 +206,9 @@ final class AddCartalystTablesToDb extends AbstractMigration
                 UNIQUE KEY `users_email_unique` (`email`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
         */
-        if( !$this->hasTable('cartalyst_users') ) {
+        if( !$this->hasTable('users') ) {
             
-            $table = $this->table('cartalyst_users');
+            $table = $this->table('users');
             $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
                   ->addColumn('email', 'string', ['limit'=>255, 'null'=>false])
                   ->addColumn('password', 'string', ['limit'=>255, 'null'=>false])
@@ -226,13 +226,13 @@ final class AddCartalystTablesToDb extends AbstractMigration
     public function down()
     {
         // place down commands here
-        $this->hasTable('cartalyst_activations') && $this->table('cartalyst_activations')->drop()->save();
-        $this->hasTable('cartalyst_persistences') && $this->table('cartalyst_persistences')->drop()->save();
-        $this->hasTable('cartalyst_reminders') && $this->table('cartalyst_reminders')->drop()->save();
-        $this->hasTable('cartalyst_roles') && $this->table('cartalyst_roles')->drop()->save();
-        $this->hasTable('cartalyst_role_users') && $this->table('cartalyst_role_users')->drop()->save();
-        $this->hasTable('cartalyst_throttle') && $this->table('cartalyst_throttle')->drop()->save();
-        $this->hasTable('cartalyst_users') && $this->table('cartalyst_users')->drop()->save();
+        $this->hasTable('activations') && $this->table('activations')->drop()->save();
+        $this->hasTable('persistences') && $this->table('persistences')->drop()->save();
+        $this->hasTable('reminders') && $this->table('reminders')->drop()->save();
+        $this->hasTable('roles') && $this->table('roles')->drop()->save();
+        $this->hasTable('role_users') && $this->table('role_users')->drop()->save();
+        $this->hasTable('throttle') && $this->table('throttle')->drop()->save();
+        $this->hasTable('users') && $this->table('users')->drop()->save();
 
     }
     

--- a/schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php
+++ b/schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php
@@ -244,3 +244,4 @@ final class AddCartalystTablesToDb extends AbstractMigration
         );
     }
 }
+

--- a/schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php
+++ b/schema/phinx-migrations/20201208222318_add_cartalyst_tables_to_db.php
@@ -1,0 +1,246 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddCartalystTablesToDb extends AbstractMigration
+{
+    public function up()
+    {
+        // place up commands here
+        /**
+        # Dump of table activations
+        # ------------------------------------------------------------
+
+            CREATE TABLE `activations` (
+              `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+              `user_id` int(10) unsigned NOT NULL,
+              `code` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+              `completed` tinyint(1) NOT NULL DEFAULT '0',
+              `completed_at` timestamp NULL DEFAULT NULL,
+              `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        */
+        if( !$this->hasTable('cartalyst_activations') ) {
+
+            $table = $this->table('cartalyst_activations');
+            $table//->addColumn('id', 'integer', ['signed' => false, 'identity' => true]) // automatically generated
+                  ->addColumn('user_id', 'integer', ['signed' => false, 'null' => false])
+                  ->addColumn('code', 'string', ['limit' => 255, 'null' => false]);
+                    
+            if($this->currentAdapterIs('mysql')) {
+            
+                $table->addColumn('completed', 'integer', ['limit' => MysqlAdapter::INT_TINY, 'null' => false, 'default' => 0]);
+                
+            } else {
+                
+                $table->addColumn('completed', 'integer', ['null' => false, 'default' => 0]);
+            }
+            
+            $table->addColumn('completed_at', 'timestamp',  ['null' => true])
+                  ->addColumn('created_at', 'timestamp',    ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp',    ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->create();
+            
+        } // if( !$this->hasTable('cartalyst_activations') )
+        
+        /**
+        # Dump of table persistences
+        # ------------------------------------------------------------
+
+            CREATE TABLE `persistences` (
+                `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+                `user_id` int(10) unsigned NOT NULL,
+                `code` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `persistences_code_unique` (`code`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        */
+        if( !$this->hasTable('cartalyst_persistences') ) {
+            
+            $table = $this->table('cartalyst_persistences');
+            $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
+                  ->addColumn('user_id', 'integer', ['signed'=>false, 'null'=>false])
+                  ->addColumn('code', 'string', ['limit'=>255, 'null'=>false])
+                  ->addColumn('created_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addIndex(['code'], ['name' => 'persistences_code_unique', 'unique' => true])
+                  ->create();
+        }
+        
+        /**
+        # Dump of table reminders
+        # ------------------------------------------------------------
+
+            CREATE TABLE `reminders` (
+                `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+                `user_id` int(10) unsigned NOT NULL,
+                `code` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `completed` tinyint(1) NOT NULL DEFAULT '0',
+                `completed_at` timestamp NULL DEFAULT NULL,
+                `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        */
+        if( !$this->hasTable('cartalyst_reminders') ) {
+            
+            $table = $this->table('cartalyst_reminders');
+            $table//->addColumn('id', 'integer', ['signed' => false, 'identity' => true]) // automatically generated
+                  ->addColumn('user_id', 'integer', ['signed' => false, 'null' => false])
+                  ->addColumn('code', 'string', ['limit' => 255, 'null' => false]);
+                    
+            if($this->currentAdapterIs('mysql')) {
+            
+                $table->addColumn('completed', 'integer', ['limit' => MysqlAdapter::INT_TINY, 'null' => false, 'default' => 0]);
+                
+            } else {
+                
+                $table->addColumn('completed', 'integer', ['null' => false, 'default' => 0]);
+            }
+            
+            $table->addColumn('completed_at', 'timestamp',  ['null' => true])
+                  ->addColumn('created_at', 'timestamp',    ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp',    ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->create();
+        }
+        
+        /**
+        # Dump of table roles
+        # ------------------------------------------------------------
+
+            CREATE TABLE `roles` (
+                `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+                `slug` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `permissions` text COLLATE utf8_unicode_ci,
+                `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `roles_slug_unique` (`slug`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci; 
+        */
+        if( !$this->hasTable('cartalyst_roles') ) {
+            
+            $table = $this->table('cartalyst_roles');
+            $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
+                  ->addColumn('slug', 'string', ['limit'=>255, 'null'=>false])
+                  ->addColumn('name', 'string', ['limit'=>255, 'null'=>false])
+                  ->addColumn('permissions', 'text', ['null'=>true])
+                  ->addColumn('created_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addIndex(['slug'], ['name' => 'roles_slug_unique', 'unique' => true])
+                  ->create();
+        }
+        
+        /**
+        # Dump of table role_users
+        # ------------------------------------------------------------
+
+            CREATE TABLE `role_users` (
+                `user_id` int(10) unsigned NOT NULL,
+                `role_id` int(10) unsigned NOT NULL,
+                `created_at` timestamp NULL DEFAULT NULL,
+                `updated_at` timestamp NULL DEFAULT NULL,
+                PRIMARY KEY (`user_id`,`role_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        */
+        if( !$this->hasTable('cartalyst_role_users') ) {
+            
+            $table = $this->table('cartalyst_role_users');
+            $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
+                  ->addColumn('user_id', 'integer', ['signed'=>false, 'null'=>false])
+                  ->addColumn('role_id', 'integer', ['signed'=>false, 'null'=>false])
+                  ->addColumn('created_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->create();
+        }
+        
+        /**
+        # Dump of table throttle
+        # ------------------------------------------------------------
+
+            CREATE TABLE `throttle` (
+                `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+                `user_id` int(10) unsigned DEFAULT NULL,
+                `type` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `ip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+                `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                KEY `throttle_user_id_index` (`user_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        */
+        if( !$this->hasTable('cartalyst_throttle') ) {
+            
+            $table = $this->table('cartalyst_throttle');
+            $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
+                  ->addColumn('user_id', 'integer', ['signed'=>false, 'null'=>false])
+                  ->addColumn('type', 'string', ['limit'=>255, 'null'=>false])
+                  ->addColumn('ip', 'string', ['limit'=>255, 'null'=>true])
+                  ->addColumn('created_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addIndex(['user_id'], ['name' => 'throttle_user_id_index'])
+                  ->create();
+        }
+        
+        /**
+        # Dump of table users
+        # ------------------------------------------------------------
+
+            CREATE TABLE `users` (
+                `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+                `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `password` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+                `permissions` text COLLATE utf8_unicode_ci,
+                `last_login` timestamp NULL DEFAULT NULL,
+                `first_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+                `last_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+                `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `users_email_unique` (`email`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        */
+        if( !$this->hasTable('cartalyst_users') ) {
+            
+            $table = $this->table('cartalyst_users');
+            $table//->addColumn('id', 'integer', ['signed'=>false, 'identity'=>true]) // automatically generated
+                  ->addColumn('email', 'string', ['limit'=>255, 'null'=>false])
+                  ->addColumn('password', 'string', ['limit'=>255, 'null'=>false])
+                  ->addColumn('permissions', 'text', ['null'=>true])
+                  ->addColumn('last_login', 'timestamp', ['null' => true])
+                  ->addColumn('first_name', 'string', ['limit'=>255, 'null'=>true])
+                  ->addColumn('last_name', 'string', ['limit'=>255, 'null'=>true])
+                  ->addColumn('created_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addColumn('updated_at', 'timestamp', ['null' => false, 'default' => 'CURRENT_TIMESTAMP'])
+                  ->addIndex(['email'], ['name' => 'users_email_unique', 'unique' => true])
+                  ->create();
+        }
+    }
+    
+    public function down()
+    {
+        // place down commands here
+        $this->hasTable('cartalyst_activations') && $this->table('cartalyst_activations')->drop()->save();
+        $this->hasTable('cartalyst_persistences') && $this->table('cartalyst_persistences')->drop()->save();
+        $this->hasTable('cartalyst_reminders') && $this->table('cartalyst_reminders')->drop()->save();
+        $this->hasTable('cartalyst_roles') && $this->table('cartalyst_roles')->drop()->save();
+        $this->hasTable('cartalyst_role_users') && $this->table('cartalyst_role_users')->drop()->save();
+        $this->hasTable('cartalyst_throttle') && $this->table('cartalyst_throttle')->drop()->save();
+        $this->hasTable('cartalyst_users') && $this->table('cartalyst_users')->drop()->save();
+
+    }
+    
+    protected function currentAdapterIs($adapter='mysql') {
+        
+        return ( 
+            trim(strtolower($this->getAdapter()->getAdapterType())) 
+            === trim(strtolower($adapter)) 
+        );
+    }
+}


### PR DESCRIPTION
Added a phinx migration class file contain schema definitions that Sentinel users comfortable with phinx could use to set up the db tables required by sentinel. This method allows the users to be able to use other db engines like sqlite, PostgreSql and MS Sql Server with sentinel.