### PR TITLE
Update SentinelServiceProvider.php

### DIFF
--- a/src/Laravel/SentinelServiceProvider.php
+++ b/src/Laravel/SentinelServiceProvider.php
@@ -206,7 +206,7 @@ class SentinelServiceProvider extends ServiceProvider
 
             foreach ($activeCheckpoints as $checkpoint) {
                 if (! $app->offsetExists("sentinel.checkpoint.{$checkpoint}")) {
-                    throw new InvalidArgumentException("Invalid checkpoint [${checkpoint}] given.");
+                    throw new InvalidArgumentException("Invalid checkpoint [{$checkpoint}] given.");
                 }
 
                 $checkpoints[$checkpoint] = $app["sentinel.checkpoint.{$checkpoint}"];


### PR DESCRIPTION
I received a deprecation warning:
```PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in vendor/cartalyst/sentinel/src/Laravel/SentinelServiceProvider.php on line 209.```
Seems like a straightforward fix, and already used on the lines above. Thanks!