### PR TITLE
Fix for deprecation notices with PHP 8.4

### DIFF
--- a/src/Activations/ActivationRepositoryInterface.php
+++ b/src/Activations/ActivationRepositoryInterface.php
@@ -41,7 +41,7 @@ interface ActivationRepositoryInterface
      *
      * @return \Cartalyst\Sentinel\Activations\ActivationInterface|null
      */
-    public function get(UserInterface $user, string $code = null): ?ActivationInterface;
+    public function get(UserInterface $user, ?string $code = null): ?ActivationInterface;
 
     /**
      * Checks if a valid activation for the given user exists.
@@ -51,7 +51,7 @@ interface ActivationRepositoryInterface
      *
      * @return bool
      */
-    public function exists(UserInterface $user, string $code = null): bool;
+    public function exists(UserInterface $user, ?string $code = null): bool;
 
     /**
      * Completes the activation for the given user.

--- a/src/Activations/IlluminateActivationRepository.php
+++ b/src/Activations/IlluminateActivationRepository.php
@@ -81,7 +81,7 @@ class IlluminateActivationRepository implements ActivationRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function get(UserInterface $user, string $code = null): ?ActivationInterface
+    public function get(UserInterface $user, ?string $code = null): ?ActivationInterface
     {
         $expires = $this->expires();
 
@@ -101,7 +101,7 @@ class IlluminateActivationRepository implements ActivationRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function exists(UserInterface $user, string $code = null): bool
+    public function exists(UserInterface $user, ?string $code = null): bool
     {
         return (bool) $this->get($user, $code);
     }

--- a/src/Checkpoints/AuthenticatedCheckpoint.php
+++ b/src/Checkpoints/AuthenticatedCheckpoint.php
@@ -27,7 +27,7 @@ trait AuthenticatedCheckpoint
     /**
      * {@inheritdoc}
      */
-    public function fail(UserInterface $user = null): bool
+    public function fail(?UserInterface $user = null): bool
     {
         return true;
     }

--- a/src/Checkpoints/CheckpointInterface.php
+++ b/src/Checkpoints/CheckpointInterface.php
@@ -51,5 +51,5 @@ interface CheckpointInterface
      *
      * @return bool
      */
-    public function fail(UserInterface $user = null): bool;
+    public function fail(?UserInterface $user = null): bool;
 }

--- a/src/Checkpoints/ThrottleCheckpoint.php
+++ b/src/Checkpoints/ThrottleCheckpoint.php
@@ -75,7 +75,7 @@ class ThrottleCheckpoint implements CheckpointInterface
     /**
      * {@inheritdoc}
      */
-    public function fail(UserInterface $user = null): bool
+    public function fail(?UserInterface $user = null): bool
     {
         // We'll check throttling firstly from any previous attempts. This
         // will throw the required exceptions if the user has already
@@ -97,7 +97,7 @@ class ThrottleCheckpoint implements CheckpointInterface
      *
      * @return bool
      */
-    protected function checkThrottling(string $action, UserInterface $user = null): bool
+    protected function checkThrottling(string $action, ?UserInterface $user = null): bool
     {
         // If we are just checking an existing logged in person, the global delay
         // shouldn't stop them being logged in at all. Only their IP address and

--- a/src/Cookies/NativeCookie.php
+++ b/src/Cookies/NativeCookie.php
@@ -116,7 +116,7 @@ class NativeCookie implements CookieInterface
      *
      * @return void
      */
-    protected function setCookie($value, int $lifetime, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null)
+    protected function setCookie($value, int $lifetime, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httpOnly = null)
     {
         setcookie(
             $this->options['name'],

--- a/src/Native/Facades/Sentinel.php
+++ b/src/Native/Facades/Sentinel.php
@@ -45,7 +45,7 @@ class Sentinel
      *
      * @return void
      */
-    public function __construct(SentinelBootstrapper $bootstrapper = null)
+    public function __construct(?SentinelBootstrapper $bootstrapper = null)
     {
         if ($bootstrapper === null) {
             $bootstrapper = new SentinelBootstrapper();
@@ -71,7 +71,7 @@ class Sentinel
      *
      * @return \Cartalyst\Sentinel\Native\SentinelBootstrapper
      */
-    public static function instance(SentinelBootstrapper $bootstrapper = null)
+    public static function instance(?SentinelBootstrapper $bootstrapper = null)
     {
         if (static::$instance === null) {
             static::$instance = new static($bootstrapper);

--- a/src/Permissions/PermissionsTrait.php
+++ b/src/Permissions/PermissionsTrait.php
@@ -53,7 +53,7 @@ trait PermissionsTrait
      *
      * @return void
      */
-    public function __construct(array $permissions = null, array $secondaryPermissions = null)
+    public function __construct(?array $permissions = null, ?array $secondaryPermissions = null)
     {
         $this->permissions = $permissions;
 

--- a/src/Persistences/IlluminatePersistenceRepository.php
+++ b/src/Persistences/IlluminatePersistenceRepository.php
@@ -67,7 +67,7 @@ class IlluminatePersistenceRepository implements PersistenceRepositoryInterface
      *
      * @return void
      */
-    public function __construct(SessionInterface $session, CookieInterface $cookie, string $model = null, bool $single = false)
+    public function __construct(SessionInterface $session, CookieInterface $cookie, ?string $model = null, bool $single = false)
     {
         $this->model = $model;
 

--- a/src/Reminders/IlluminateReminderRepository.php
+++ b/src/Reminders/IlluminateReminderRepository.php
@@ -60,7 +60,7 @@ class IlluminateReminderRepository implements ReminderRepositoryInterface
      *
      * @return void
      */
-    public function __construct(UserRepositoryInterface $users, string $model = null, int $expires = null)
+    public function __construct(UserRepositoryInterface $users, ?string $model = null, ?int $expires = null)
     {
         $this->users = $users;
 
@@ -93,7 +93,7 @@ class IlluminateReminderRepository implements ReminderRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function get(UserInterface $user, string $code = null)
+    public function get(UserInterface $user, ?string $code = null)
     {
         $expires = $this->expires();
 
@@ -115,7 +115,7 @@ class IlluminateReminderRepository implements ReminderRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function exists(UserInterface $user, string $code = null): bool
+    public function exists(UserInterface $user, ?string $code = null): bool
     {
         return (bool) $this->get($user, $code);
     }

--- a/src/Reminders/ReminderRepositoryInterface.php
+++ b/src/Reminders/ReminderRepositoryInterface.php
@@ -41,7 +41,7 @@ interface ReminderRepositoryInterface
      *
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function get(UserInterface $user, string $code = null);
+    public function get(UserInterface $user, ?string $code = null);
 
     /**
      * Check if a valid reminder exists.
@@ -51,7 +51,7 @@ interface ReminderRepositoryInterface
      *
      * @return bool
      */
-    public function exists(UserInterface $user, string $code = null): bool;
+    public function exists(UserInterface $user, ?string $code = null): bool;
 
     /**
      * Complete reminder for the given user.

--- a/src/Roles/IlluminateRoleRepository.php
+++ b/src/Roles/IlluminateRoleRepository.php
@@ -40,7 +40,7 @@ class IlluminateRoleRepository implements RoleRepositoryInterface
      *
      * @return void
      */
-    public function __construct(string $model = null)
+    public function __construct(?string $model = null)
     {
         $this->model = $model;
     }

--- a/src/Sentinel.php
+++ b/src/Sentinel.php
@@ -535,7 +535,7 @@ class Sentinel
      *
      * @return bool
      */
-    public function logout(UserInterface $user = null, bool $everywhere = false): bool
+    public function logout(?UserInterface $user = null, bool $everywhere = false): bool
     {
         $currentUser = $this->check();
 
@@ -692,7 +692,7 @@ class Sentinel
      *
      * @return bool
      */
-    protected function cycleCheckpoints(string $method, UserInterface $user = null, bool $halt = true): bool
+    protected function cycleCheckpoints(string $method, ?UserInterface $user = null, bool $halt = true): bool
     {
         if (! $this->checkpointsStatus) {
             return true;

--- a/src/Sessions/IlluminateSession.php
+++ b/src/Sessions/IlluminateSession.php
@@ -46,7 +46,7 @@ class IlluminateSession implements SessionInterface
      *
      * @return void
      */
-    public function __construct(SessionStore $session, string $key = null)
+    public function __construct(SessionStore $session, ?string $key = null)
     {
         $this->session = $session;
 

--- a/src/Sessions/NativeSession.php
+++ b/src/Sessions/NativeSession.php
@@ -36,7 +36,7 @@ class NativeSession implements SessionInterface
      *
      * @return void
      */
-    public function __construct(string $key = null)
+    public function __construct(?string $key = null)
     {
         $this->key = $key;
 

--- a/src/Throttling/IlluminateThrottleRepository.php
+++ b/src/Throttling/IlluminateThrottleRepository.php
@@ -189,7 +189,7 @@ class IlluminateThrottleRepository implements ThrottleRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function log($ipAddress = null, UserInterface $user = null)
+    public function log($ipAddress = null, ?UserInterface $user = null)
     {
         $global = $this->createModel();
         $global->fill([

--- a/src/Throttling/ThrottleRepositoryInterface.php
+++ b/src/Throttling/ThrottleRepositoryInterface.php
@@ -57,5 +57,5 @@ interface ThrottleRepositoryInterface
      *
      * @return void
      */
-    public function log($ipAddress = null, UserInterface $user = null);
+    public function log($ipAddress = null, ?UserInterface $user = null);
 }

--- a/src/Users/IlluminateUserRepository.php
+++ b/src/Users/IlluminateUserRepository.php
@@ -55,7 +55,7 @@ class IlluminateUserRepository implements UserRepositoryInterface
      *
      * @return void
      */
-    public function __construct(HasherInterface $hasher, Dispatcher $dispatcher = null, string $model = null)
+    public function __construct(HasherInterface $hasher, ?Dispatcher $dispatcher = null, ?string $model = null)
     {
         $this->hasher = $hasher;
 
@@ -173,7 +173,7 @@ class IlluminateUserRepository implements UserRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create(array $credentials, Closure $callback = null): ?UserInterface
+    public function create(array $credentials, ?Closure $callback = null): ?UserInterface
     {
         $user = $this->createModel();
 
@@ -326,7 +326,7 @@ class IlluminateUserRepository implements UserRepositoryInterface
      *
      * @return bool
      */
-    protected function validateUser(array $credentials, int $id = null): bool
+    protected function validateUser(array $credentials, ?int $id = null): bool
     {
         $instance = $this->createModel();
 

--- a/src/Users/UserRepositoryInterface.php
+++ b/src/Users/UserRepositoryInterface.php
@@ -106,7 +106,7 @@ interface UserRepositoryInterface
      *
      * @return \Cartalyst\Sentinel\Users\UserInterface|null
      */
-    public function create(array $credentials, Closure $callback = null): ?UserInterface;
+    public function create(array $credentials, ?Closure $callback = null): ?UserInterface;
 
     /**
      * Updates a user.


### PR DESCRIPTION
Fixes deprecation notices of explicit nullable type with PHP 8.4. 

Mentioned in issue: https://github.com/cartalyst/sentinel/issues/582